### PR TITLE
fix the nb builds by removing the \r's

### DIFF
--- a/doc/examples/py_double_ml_multiway_cluster.ipynb
+++ b/doc/examples/py_double_ml_multiway_cluster.ipynb
@@ -2,6 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "mNcwBqn11_ZX"
+   },
    "source": [
     "# Python: Cluster Robust Double Machine Learning\n",
     "\n",
@@ -23,38 +26,38 @@
     "https://docs.doubleml.org/stable/guide/basics.html#sample-splitting-to-remove-bias-induced-by-overfitting) as well as to the explanation in [Chernozhukov et al. (2018)](https://doi.org/10.1111/ectj.12097) .\n",
     "\n",
     "In order to achieve independent data splits in a setting with one-way or multi-way clustering, [Chiang et al. (2021)](https://doi.org/10.1080/07350015.2021.1895815) develop an updated  $K$-fold sample splitting procedure that ensures independent sample splits: The data set is split into disjoint partitions in terms of all clustering dimensions. For example, in a situation with two-way clustering, the data is split into $K^2$ folds. The machine learning models are then trained on a specific fold and used for generation of predictions in hold-out samples. Thereby, the sample splitting procedure ensures that the hold-out samples do not contain observations of the same clusters as used for training.\n"
-   ],
-   "metadata": {
-    "id": "mNcwBqn11_ZX"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "import numpy as np\r\n",
-    "import pandas as pd\r\n",
-    "\r\n",
-    "import matplotlib.pyplot as plt\r\n",
-    "from matplotlib.colors import ListedColormap\r\n",
-    "import seaborn as sns\r\n",
-    "\r\n",
-    "from sklearn.model_selection import KFold, RepeatedKFold\r\n",
-    "from sklearn.base import clone\r\n",
-    "\r\n",
-    "from sklearn.linear_model import LassoCV\r\n",
-    "\r\n",
-    "from doubleml import DoubleMLClusterData, DoubleMLData, DoubleMLPLIV\r\n",
-    "\r\n",
-    "from doubleml.datasets import make_pliv_multiway_cluster_CKMS2021"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "r1nf2-YD1_Z2"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import ListedColormap\n",
+    "import seaborn as sns\n",
+    "\n",
+    "from sklearn.model_selection import KFold, RepeatedKFold\n",
+    "from sklearn.base import clone\n",
+    "\n",
+    "from sklearn.linear_model import LassoCV\n",
+    "\n",
+    "from doubleml import DoubleMLClusterData, DoubleMLData, DoubleMLPLIV\n",
+    "\n",
+    "from doubleml.datasets import make_pliv_multiway_cluster_CKMS2021"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "1lptyTy61_Z_"
+   },
    "source": [
     "## A Motivating Example: Two-Way Cluster Robust DML\n",
     "\n",
@@ -71,13 +74,13 @@
     "Y_{ij} = D_{ij} \\theta_0 +  g_0(X_{ij}) + \\epsilon_{ij}, & &\\mathbb{E}(\\epsilon_{ij} | X_{ij}, Z_{ij}) = 0, \\\\\n",
     "Z_{ij} = m_0(X_{ij}) + v_{ij}, & &\\mathbb{E}(v_{ij} | X_{ij}) = 0.\n",
     "\\end{aligned}$$"
-   ],
-   "metadata": {
-    "id": "1lptyTy61_Z_"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "9L-nrVMH1_aD"
+   },
    "source": [
     "### Simulate two-way cluster data\n",
     "\n",
@@ -113,14 +116,15 @@
     "and $\\alpha_{ij}^V, \\alpha_{i}^V, \\alpha_{j}^V \\sim \\mathcal{N}(0, 1)$.\n",
     "\n",
     "Data from this DGP can be generated with the [make_pliv_multiway_cluster_CKMS2021()](https://docs.doubleml.org/stable/api/generated/doubleml.datasets.make_pliv_multiway_cluster_CKMS2021.html#doubleml.datasets.make_pliv_multiway_cluster_CKMS2021) function from [DoubleML](https://docs.doubleml.org/stable/index.html)."
-   ],
-   "metadata": {
-    "id": "9L-nrVMH1_aD"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "9hepXKz91_aM"
+   },
+   "outputs": [],
    "source": [
     "# Set the simulation parameters\n",
     "N = 25  # number of observations (first dimension)\n",
@@ -129,58 +133,58 @@
     "np.random.seed(3141) # set seed\n",
     "\n",
     "obj_dml_data = make_pliv_multiway_cluster_CKMS2021(N, M, dim_X)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "9hepXKz91_aM"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "rlePOlu21_aP"
+   },
    "source": [
     "### Data-Backend for Cluster Data\n",
     "The implementation of cluster robust double machine learning is based on a special data-backend called [DoubleMLClusterData](https://docs.doubleml.org/stable/api/generated/doubleml.DoubleMLClusterData.html#doubleml.DoubleMLClusterData). As compared to the standard data-backend [DoubleMLData](https://docs.doubleml.org/dev/api/generated/doubleml.DoubleMLData.html), users can specify the clustering variables during instantiation of a  [DoubleMLClusterData](https://docs.doubleml.org/stable/api/generated/doubleml.DoubleMLClusterData.html#doubleml.DoubleMLClusterData) object. The estimation framework will subsequently account for the provided clustering options."
-   ],
-   "metadata": {
-    "id": "rlePOlu21_aP"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "N9DBwEFT1_aS"
+   },
+   "outputs": [],
    "source": [
     "# The simulated data is of type DoubleMLClusterData\n",
     "print(obj_dml_data)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "N9DBwEFT1_aS"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "yMU5Y0n81_aW"
+   },
+   "outputs": [],
    "source": [
     "# The cluster variables are part of the DataFrame\n",
     "obj_dml_data.data.head()"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "yMU5Y0n81_aW"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Initialize the objects of class `DoubleMLPLIV`"
-   ],
    "metadata": {
     "id": "hPXEpA3J1_aa"
-   }
+   },
+   "source": [
+    "### Initialize the objects of class `DoubleMLPLIV`"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "DvjBpafF1_ae"
+   },
+   "outputs": [],
    "source": [
     "# Set machine learning methods for m, g & r\n",
     "learner = LassoCV()\n",
@@ -192,108 +196,107 @@
     "dml_pliv_obj = DoubleMLPLIV(obj_dml_data,\n",
     "                            ml_g, ml_m, ml_r,\n",
     "                            n_folds=3)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "DvjBpafF1_ae"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "print(dml_pliv_obj)"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "rh3-MK2Q1_ah"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "print(dml_pliv_obj)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Define Helper Functions for Plotting"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "#discrete color scheme\n",
     "x = sns.color_palette(\"RdBu_r\", 7)\n",
     "cMap = ListedColormap([x[0], x[3], x[6]])\n",
     "plt.rcParams['figure.figsize'] = 15, 12\n",
     "sns.set(font_scale=1.3)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "def plt_smpls(smpls, n_folds_per_cluster):\r\n",
-    "    df = pd.DataFrame(np.zeros([N*M, n_folds_per_cluster*n_folds_per_cluster]))\r\n",
-    "    for i_split, this_split_ind in enumerate(smpls):\r\n",
-    "        df.loc[this_split_ind[0], i_split] = -1.\r\n",
-    "        df.loc[this_split_ind[1], i_split] = 1.\r\n",
-    "\r\n",
-    "    ax = sns.heatmap(df, cmap=cMap);\r\n",
-    "    ax.invert_yaxis();\r\n",
-    "    ax.set_ylim([0, N*M]);\r\n",
-    "    ax.set_xlabel('Fold')\r\n",
-    "    ax.set_ylabel('Observation')\r\n",
-    "    colorbar = ax.collections[0].colorbar\r\n",
-    "    colorbar.set_ticks([-0.667, 0, 0.667])\r\n",
+    "def plt_smpls(smpls, n_folds_per_cluster):\n",
+    "    df = pd.DataFrame(np.zeros([N*M, n_folds_per_cluster*n_folds_per_cluster]))\n",
+    "    for i_split, this_split_ind in enumerate(smpls):\n",
+    "        df.loc[this_split_ind[0], i_split] = -1.\n",
+    "        df.loc[this_split_ind[1], i_split] = 1.\n",
+    "\n",
+    "    ax = sns.heatmap(df, cmap=cMap);\n",
+    "    ax.invert_yaxis();\n",
+    "    ax.set_ylim([0, N*M]);\n",
+    "    ax.set_xlabel('Fold')\n",
+    "    ax.set_ylabel('Observation')\n",
+    "    colorbar = ax.collections[0].colorbar\n",
+    "    colorbar.set_ticks([-0.667, 0, 0.667])\n",
     "    colorbar.set_ticklabels(['Nuisance', '', 'Score'])"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "def plt_smpls_cluster(smpls_cluster, n_folds_per_cluster):\r\n",
-    "    for i_split in range(len(smpls_cluster)):\r\n",
-    "        plt.subplot(n_folds_per_cluster, n_folds_per_cluster, i_split + 1)\r\n",
-    "        df = pd.DataFrame(np.zeros([N*M, 1]),\r\n",
-    "                      index = pd.MultiIndex.from_product([range(N), range(M)]),\r\n",
-    "                      columns=['value'])\r\n",
-    "\r\n",
-    "        df.loc[pd.MultiIndex.from_product(smpls_cluster[i_split][0]), :] = -1.\r\n",
-    "        df.loc[pd.MultiIndex.from_product(smpls_cluster[i_split][1]), :] = 1.\r\n",
-    "\r\n",
-    "        df_wide = df.reset_index().pivot(index=\"level_0\", columns=\"level_1\", values=\"value\")\r\n",
-    "        df_wide.index.name=''\r\n",
-    "        df_wide.columns.name=''\r\n",
-    "\r\n",
-    "        ax = sns.heatmap(df_wide, cmap=cMap);\r\n",
-    "        ax.invert_yaxis();\r\n",
-    "        ax.set_ylim([0, M]);\r\n",
-    "        colorbar = ax.collections[0].colorbar\r\n",
-    "        colorbar.set_ticks([-0.667, 0, 0.667])\r\n",
-    "\r\n",
-    "        l = i_split % n_folds_per_cluster + 1\r\n",
-    "        k = np.floor_divide(i_split, n_folds_per_cluster) + 1\r\n",
-    "        title = f'Nuisance: $I_{{{k}}}^C \\\\times J_{{{l}}}^C$; Score: $I_{{{k}}} \\\\times J_{{{l}}}$'\r\n",
-    "        ax.set_title(title)\r\n",
-    "        if l == n_folds_per_cluster:\r\n",
-    "            colorbar.set_ticklabels(['Nuisance', '', 'Score'])\r\n",
-    "        else:\r\n",
-    "            colorbar.set_ticklabels(['', '', ''])\r\n",
-    "        if l == 1:\r\n",
-    "            ax.set_ylabel('First Cluster Variable $k$')\r\n",
-    "        if k == 3:\r\n",
-    "            ax.set_xlabel('Second Cluster Variable $\\ell$')\r\n",
-    "    plt.tight_layout()"
-   ],
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": [
+    "def plt_smpls_cluster(smpls_cluster, n_folds_per_cluster):\n",
+    "    for i_split in range(len(smpls_cluster)):\n",
+    "        plt.subplot(n_folds_per_cluster, n_folds_per_cluster, i_split + 1)\n",
+    "        df = pd.DataFrame(np.zeros([N*M, 1]),\n",
+    "                      index = pd.MultiIndex.from_product([range(N), range(M)]),\n",
+    "                      columns=['value'])\n",
+    "\n",
+    "        df.loc[pd.MultiIndex.from_product(smpls_cluster[i_split][0]), :] = -1.\n",
+    "        df.loc[pd.MultiIndex.from_product(smpls_cluster[i_split][1]), :] = 1.\n",
+    "\n",
+    "        df_wide = df.reset_index().pivot(index=\"level_0\", columns=\"level_1\", values=\"value\")\n",
+    "        df_wide.index.name=''\n",
+    "        df_wide.columns.name=''\n",
+    "\n",
+    "        ax = sns.heatmap(df_wide, cmap=cMap);\n",
+    "        ax.invert_yaxis();\n",
+    "        ax.set_ylim([0, M]);\n",
+    "        colorbar = ax.collections[0].colorbar\n",
+    "        colorbar.set_ticks([-0.667, 0, 0.667])\n",
+    "\n",
+    "        l = i_split % n_folds_per_cluster + 1\n",
+    "        k = np.floor_divide(i_split, n_folds_per_cluster) + 1\n",
+    "        title = f'Nuisance: $I_{{{k}}}^C \\\\times J_{{{l}}}^C$; Score: $I_{{{k}}} \\\\times J_{{{l}}}$'\n",
+    "        ax.set_title(title)\n",
+    "        if l == n_folds_per_cluster:\n",
+    "            colorbar.set_ticklabels(['Nuisance', '', 'Score'])\n",
+    "        else:\n",
+    "            colorbar.set_ticklabels(['', '', ''])\n",
+    "        if l == 1:\n",
+    "            ax.set_ylabel('First Cluster Variable $k$')\n",
+    "        if k == 3:\n",
+    "            ax.set_xlabel('Second Cluster Variable $\\ell$')\n",
+    "    plt.tight_layout()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "dbxf265L1_ak"
+   },
    "source": [
     "### Cluster Robust Cross Fitting\n",
     "A key element of cluster robust DML ([Chiang et al. 2021](https://doi.org/10.1080/07350015.2021.1895815)) is a special sample splitting used for the cross-fitting.\n",
@@ -313,69 +316,69 @@
     "$$\n",
     "for $\\tilde{\\theta}_0$.\n",
     "Here $|I_k|$ denotes the cardinality, i.e., the number of clusters in the $k$-th fold for the first cluster variable."
-   ],
-   "metadata": {
-    "id": "dbxf265L1_ak"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "CwgzBXvQ1_am"
+   },
    "source": [
     "We can visualize the sample splitting of the $N \\cdot M = 625$ observations into $K \\cdot K = 9$ folds. The following heat map illustrates the partitioned data set that is split into $K=9$ folds. The horizontal axis corresponds to the fold indices and the vertical axis to the indices of the observations. A blue field indicates that the observation $i$ is used for fitting the nuisance part, red indicates that the fold is used for prediction generation and white means that an observation is left out from the sample splitting. \n",
     "\n",
     "For example, the first observation as displayed on the very bottom of the figure (using Python indexing starting at `0`) is used for training of the nuisance parts in the first (`0`), the third (`2`), fourth (`3`) and sixth (`5`) fold and used for generation of the predictions in fold eight (`7`). At the same time the observation is left out from the sample splitting procedure in folds two (`1`), five (`4`), seven (`6`) and nine (`8`)."
-   ],
-   "metadata": {
-    "id": "CwgzBXvQ1_am"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "plt_smpls(dml_pliv_obj.smpls[0], dml_pliv_obj._n_folds_per_cluster)"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "2eU-ukl81_ar"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "plt_smpls(dml_pliv_obj.smpls[0], dml_pliv_obj._n_folds_per_cluster)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "If we visualize the sample splitting in terms of the cluster variables, the partitioning of the data into $9$ folds $I_k \\times J_\\ell$ becomes clear.\r\n",
-    "The identifiers for the first cluster variable $[N]:=\\{1,\\ldots,N\\}$ have been randomly partioned into $K=3$ folds denoted by $\\{I_1, I_2, I_3\\}$ and the identifiers for the second cluster variable $[M]:=\\{1,\\ldots,M\\}$ have also been randomly partioned into $K=3$ folds denoted by $\\{J_1, J_2, J_3\\}$.\r\n",
-    "By considering every combination $I_k \\times J_\\ell$ for $1 \\leq k, \\ell \\leq K = 3$ we effectively base the cross-fitting on $9$ folds.\r\n",
-    "\r\n",
-    "We now want to focus on the top-left sub-plot showing the partitioning of the cluster data for the first fold.\r\n",
-    "The $x$-axis corresponds to the first cluster variable and the $y$-axis to the second cluster variable.\r\n",
-    "Observations with cluster variables $(i,j) \\in I_K \\times J_\\ell$ are used for estimation of the target parameter $\\tilde{\\theta}_0$ by solving a Neyman orthogonal score function.\r\n",
-    "For estimation of the nuisance function, we only use observation where neither the first cluster variable is in $I_K$ nor the second cluster variable is in $J_\\ell$, i.e., we use observations indexed by $(i,j)\\in ([N]\\setminus I_K) \\times ([M]\\setminus J_\\ell)$ to estimate the nuisance functions\r\n",
-    "$$\r\n",
-    "\\hat{\\eta}_{k\\ell} = \\hat{\\eta}\\left((W_{ij})_{(i,j)\\in ([N]\\setminus I_K) \\times ([M]\\setminus J_\\ell)}\\right).\r\n",
-    "$$\r\n",
-    "This way we guarantee that there are never observations from the same cluster (first and/or second cluster dimension) in the sample for the nuisance function estimation (blue) and at the same time in the sample for solving the score function (red). As a result of this special sample splitting proposed by [Chiang et al. (2021)](https://doi.org/10.1080/07350015.2021.1895815), the observations in the score (red) and nuisance (blue) sample can be considered independent and the standard cross-fitting approach for double machine learning can be applied."
-   ],
    "metadata": {
     "id": "WbylaFQx1_ay"
-   }
+   },
+   "source": [
+    "If we visualize the sample splitting in terms of the cluster variables, the partitioning of the data into $9$ folds $I_k \\times J_\\ell$ becomes clear.\n",
+    "The identifiers for the first cluster variable $[N]:=\\{1,\\ldots,N\\}$ have been randomly partioned into $K=3$ folds denoted by $\\{I_1, I_2, I_3\\}$ and the identifiers for the second cluster variable $[M]:=\\{1,\\ldots,M\\}$ have also been randomly partioned into $K=3$ folds denoted by $\\{J_1, J_2, J_3\\}$.\n",
+    "By considering every combination $I_k \\times J_\\ell$ for $1 \\leq k, \\ell \\leq K = 3$ we effectively base the cross-fitting on $9$ folds.\n",
+    "\n",
+    "We now want to focus on the top-left sub-plot showing the partitioning of the cluster data for the first fold.\n",
+    "The $x$-axis corresponds to the first cluster variable and the $y$-axis to the second cluster variable.\n",
+    "Observations with cluster variables $(i,j) \\in I_K \\times J_\\ell$ are used for estimation of the target parameter $\\tilde{\\theta}_0$ by solving a Neyman orthogonal score function.\n",
+    "For estimation of the nuisance function, we only use observation where neither the first cluster variable is in $I_K$ nor the second cluster variable is in $J_\\ell$, i.e., we use observations indexed by $(i,j)\\in ([N]\\setminus I_K) \\times ([M]\\setminus J_\\ell)$ to estimate the nuisance functions\n",
+    "$$\n",
+    "\\hat{\\eta}_{k\\ell} = \\hat{\\eta}\\left((W_{ij})_{(i,j)\\in ([N]\\setminus I_K) \\times ([M]\\setminus J_\\ell)}\\right).\n",
+    "$$\n",
+    "This way we guarantee that there are never observations from the same cluster (first and/or second cluster dimension) in the sample for the nuisance function estimation (blue) and at the same time in the sample for solving the score function (red). As a result of this special sample splitting proposed by [Chiang et al. (2021)](https://doi.org/10.1080/07350015.2021.1895815), the observations in the score (red) and nuisance (blue) sample can be considered independent and the standard cross-fitting approach for double machine learning can be applied."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "plt_smpls_cluster(dml_pliv_obj.smpls_cluster[0], dml_pliv_obj._n_folds_per_cluster)"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "KfI-DvHV1_a1",
     "tags": [
      "nbsphinx-thumbnail"
     ]
-   }
+   },
+   "outputs": [],
+   "source": [
+    "plt_smpls_cluster(dml_pliv_obj.smpls_cluster[0], dml_pliv_obj._n_folds_per_cluster)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "wS8OuXQG1_a5"
+   },
    "source": [
     "### Cluster Robust Standard Errors\n",
     "In the abstract base class `DoubleML` the estimation of cluster robust standard errors is implemented for all supported double machine learning models.\n",
@@ -416,26 +419,26 @@
     "\\end{aligned}\n",
     "$$\n",
     "with $\\underline{C} = N \\wedge M$."
-   ],
-   "metadata": {
-    "id": "wS8OuXQG1_a5"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "# Estimate the PLIV model with cluster robust double machine learning\r\n",
-    "dml_pliv_obj.fit()\r\n",
-    "dml_pliv_obj.summary"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "ZcNPzPnC1_a9"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "# Estimate the PLIV model with cluster robust double machine learning\n",
+    "dml_pliv_obj.fit()\n",
+    "dml_pliv_obj.summary"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "XNRVgYrF1_bA"
+   },
    "source": [
     "## (One-Way) Cluster Robust Double Machine Learing\n",
     "\n",
@@ -445,41 +448,42 @@
     "\\omega_2^X = \\omega_2^\\varepsilon = \\omega_2^v = \\omega_2^V = 0.\n",
     "$$\n",
     "Again we can simulate this data with [make_pliv_multiway_cluster_CKMS2021()](https://docs.doubleml.org/stable/api/generated/doubleml.datasets.make_pliv_multiway_cluster_CKMS2021.html#doubleml.datasets.make_pliv_multiway_cluster_CKMS2021). To prepare the data-backend for one-way clustering, we only have to alter the `cluster_cols` to be `'cluster_var_i'`."
-   ],
-   "metadata": {
-    "id": "XNRVgYrF1_bA"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "obj_dml_data = make_pliv_multiway_cluster_CKMS2021(N, M, dim_X,\r\n",
-    "                                                   omega_X=np.array([0.25, 0]),\r\n",
-    "                                                   omega_epsilon=np.array([0.25, 0]),\r\n",
-    "                                                   omega_v=np.array([0.25, 0]),\r\n",
-    "                                                   omega_V=np.array([0.25, 0]))"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "EvJ-wHSV1_bD"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "obj_dml_data = make_pliv_multiway_cluster_CKMS2021(N, M, dim_X,\n",
+    "                                                   omega_X=np.array([0.25, 0]),\n",
+    "                                                   omega_epsilon=np.array([0.25, 0]),\n",
+    "                                                   omega_v=np.array([0.25, 0]),\n",
+    "                                                   omega_V=np.array([0.25, 0]))"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "UIMLXmD51_bF"
+   },
+   "outputs": [],
    "source": [
     "obj_dml_data.cluster_cols = 'cluster_var_i'\n",
     "print(obj_dml_data)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "UIMLXmD51_bF"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "Jb0zciH41_bJ"
+   },
+   "outputs": [],
    "source": [
     "# Set machine learning methods for m & g\n",
     "learner = LassoCV()\n",
@@ -491,85 +495,85 @@
     "dml_pliv_obj = DoubleMLPLIV(obj_dml_data,\n",
     "                            ml_g, ml_m, ml_r,\n",
     "                            n_folds=3)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "Jb0zciH41_bJ"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "DcQHiCFG1_bN"
+   },
+   "outputs": [],
    "source": [
     "dml_pliv_obj.fit()\n",
     "dml_pliv_obj.summary"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "DcQHiCFG1_bN"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "BViUo9UW1_bZ"
+   },
    "source": [
     "## Real-Data Application\n",
     "As a real-data application we revist the consumer demand example from [Chiang et al. (2021)](https://doi.org/10.1080/07350015.2021.1895815).\n",
     "The U.S. automobile data of [Berry, Levinsohn, and Pakes (1995)](https://doi.org/10.2307/2171802) is obtained from the `R` package [hdm](https://cran.r-project.org/web/packages/hdm/index.html). In this example, we consider different specifications for the cluster dimensions."
-   ],
-   "metadata": {
-    "id": "BViUo9UW1_bZ"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Load and Process Data"
-   ],
    "metadata": {
     "id": "A7p7eaeO1_bb"
-   }
+   },
+   "source": [
+    "### Load and Process Data"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "SM30YzZo1_bh"
+   },
+   "outputs": [],
    "source": [
     "from sklearn.preprocessing import PolynomialFeatures\n",
     "from rpy2.robjects.packages import importr, data\n",
     "from rpy2.robjects import r, pandas2ri\n",
     "pandas2ri.activate()"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "SM30YzZo1_bh"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "kWO-X1aZ1_bj"
+   },
+   "outputs": [],
    "source": [
     "hdm = importr('hdm')\n",
     "blp_data = data(hdm).fetch('BLP')['BLP'][0]"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "kWO-X1aZ1_bj"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "Kzu6GG2i1_bo"
+   },
+   "outputs": [],
    "source": [
     "x_cols = ['hpwt', 'air', 'mpd', 'space']\n",
     "blp_data"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "Kzu6GG2i1_bo"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "5WIE4GPS1_bq"
+   },
+   "outputs": [],
    "source": [
     "def construct_iv(blp_data, x_cols=['hpwt', 'air', 'mpd', 'space']):\n",
     "    n = blp_data.shape[0]\n",
@@ -593,56 +597,56 @@
     "            sum_rival.iloc[i, j] = X.iloc[:,j][rival_ind].sum()\n",
     "    \n",
     "    return pd.concat((sum_other, sum_rival), axis=1)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "5WIE4GPS1_bq"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "iv_vars = construct_iv(blp_data, x_cols=['hpwt', 'air', 'mpd', 'space'])"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "2iTzEmsT1_br"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "iv_vars = construct_iv(blp_data, x_cols=['hpwt', 'air', 'mpd', 'space'])"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "vjJEPgd61_bs"
+   },
+   "outputs": [],
    "source": [
     "poly = PolynomialFeatures(degree=3, include_bias=False)\n",
     "data_transf = poly.fit_transform(blp_data[x_cols])\n",
     "x_cols_poly = poly.get_feature_names(x_cols)\n",
     "data_transf = pd.DataFrame(data_transf, columns=x_cols_poly)\n",
     "data_transf.index = blp_data.index"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "vjJEPgd61_bs"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "VzG84J7K1_b3",
+    "scrolled": true
+   },
+   "outputs": [],
    "source": [
     "sel_cols_chiang = list(np.setdiff1d(data_transf.columns,\n",
     "                                    ['hpwt air mpd', 'hpwt air space',\n",
     "                                     'hpwt mpd space', 'air mpd space']))\n",
     "sel_cols_chiang"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "VzG84J7K1_b3",
-    "scrolled": true
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "M8IeK-0A1_b6"
+   },
+   "outputs": [],
    "source": [
     "blp_data['log_p'] = np.log(blp_data['price'] + 11.761)\n",
     "\n",
@@ -651,49 +655,49 @@
     "cluster_cols = ['model.id', 'cdid']\n",
     "all_z_cols = ['sum.other.hpwt', 'sum.other.mpd', 'sum.other.space']\n",
     "z_col = all_z_cols[0]"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "M8IeK-0A1_b6"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "7eVrppKH1_b7"
+   },
+   "outputs": [],
    "source": [
     "dml_df = pd.concat((blp_data[[y_col] + [d_col] + cluster_cols],\n",
     "                    data_transf[sel_cols_chiang],\n",
     "                    iv_vars[all_z_cols]),\n",
     "                   axis=1)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "7eVrppKH1_b7"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "dml_df.shape"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "ezGVW5Gl1_b8"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "dml_df.shape"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Initialize `DoubleMLClusterData` object"
-   ],
    "metadata": {
     "id": "05nt4NKc1_b9"
-   }
+   },
+   "source": [
+    "### Initialize `DoubleMLClusterData` object"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "ik3fUxCn1_cH"
+   },
+   "outputs": [],
    "source": [
     "dml_data = DoubleMLClusterData(dml_df,\n",
     "                               y_col=y_col,\n",
@@ -701,58 +705,58 @@
     "                               z_cols=z_col,\n",
     "                               cluster_cols=cluster_cols,\n",
     "                               x_cols=sel_cols_chiang)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "ik3fUxCn1_cH"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "print(dml_data)"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "7Y4wQOsC1_cJ"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "print(dml_data)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "learner = LassoCV(max_iter=50000)"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "LGgk1Yfy1_cK"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "learner = LassoCV(max_iter=50000)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "GssTYt2i1_cM"
+   },
+   "outputs": [],
    "source": [
     "res_df = pd.DataFrame()\n",
     "n_rep = 10"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "GssTYt2i1_cM"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Two-Way Clustering with Respect to Product and Market"
-   ],
    "metadata": {
     "id": "wsagdd4V1_cN"
-   }
+   },
+   "source": [
+    "### Two-Way Clustering with Respect to Product and Market"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "Dd2InB0w1_cO"
+   },
+   "outputs": [],
    "source": [
     "dml_data.z_cols = z_col\n",
     "dml_data.cluster_cols = ['model.id', 'cdid']\n",
@@ -764,24 +768,24 @@
     "res['z_col'] = dml_data.z_cols[0]\n",
     "res['clustering'] = 'two-way'\n",
     "res_df = res_df.append(res)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "Dd2InB0w1_cO"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### One-Way Clustering with Respect to the Product"
-   ],
    "metadata": {
     "id": "n3RhZ4fH1_cS"
-   }
+   },
+   "source": [
+    "### One-Way Clustering with Respect to the Product"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "dqJxk4S61_cV"
+   },
+   "outputs": [],
    "source": [
     "dml_data.z_cols = z_col\n",
     "dml_data.cluster_cols = 'model.id'\n",
@@ -793,24 +797,24 @@
     "res['z_col'] = dml_data.z_cols[0]\n",
     "res['clustering'] = 'one-way-product'\n",
     "res_df = res_df.append(res)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "dqJxk4S61_cV"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### One-Way Clustering with Respect to the Market"
-   ],
    "metadata": {
     "id": "ODt4TiKL1_cX"
-   }
+   },
+   "source": [
+    "### One-Way Clustering with Respect to the Market"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "dl2CTDBu1_cY"
+   },
+   "outputs": [],
    "source": [
     "dml_data.z_cols = z_col\n",
     "dml_data.cluster_cols = 'cdid'\n",
@@ -822,50 +826,50 @@
     "res['z_col'] = dml_data.z_cols[0]\n",
     "res['clustering'] = 'one-way-market'\n",
     "res_df = res_df.append(res)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "dl2CTDBu1_cY"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### No Clustering / Zero-Way Clustering"
-   ],
    "metadata": {
     "id": "96RUevUV1_cZ"
-   }
+   },
+   "source": [
+    "### No Clustering / Zero-Way Clustering"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "wkKU9Fxx1_cc"
+   },
+   "outputs": [],
    "source": [
     "dml_data = DoubleMLData(dml_df,\n",
     "                        y_col=y_col,\n",
     "                        d_cols=d_col,\n",
     "                        z_cols=z_col,\n",
     "                        x_cols=sel_cols_chiang)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "wkKU9Fxx1_cc"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "print(dml_data)"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "xxCoX1CP1_cd"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "print(dml_data)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "WY3iQ5aO1_cq"
+   },
+   "outputs": [],
    "source": [
     "dml_data.z_cols = z_col\n",
     "dml_pliv = DoubleMLPLIV(dml_data,\n",
@@ -876,34 +880,33 @@
     "res['z_col'] = dml_data.z_cols[0]\n",
     "res['clustering'] = 'zero-way'\n",
     "res_df = res_df.append(res)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "WY3iQ5aO1_cq"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Application Results"
-   ],
    "metadata": {
     "id": "Hmc3x1n-1_cr"
-   }
+   },
+   "source": [
+    "### Application Results"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "res_df"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "PO-RMWTe1_cs"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "res_df"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "NhIE_t-A1_ct"
+   },
    "source": [
     "## References\n",
     "Berry, S., Levinsohn, J., and Pakes, A. (1995), Automobile Prices in Market\n",
@@ -914,10 +917,7 @@
     "Chernozhukov, V., Chetverikov, D., Demirer, M., Duflo, E., Hansen, C., Newey, W. and Robins, J. (2018), Double/debiased machine learning for treatment and structural parameters. The Econometrics Journal, 21: C1-C68, doi: [10.1111/ectj.12097](https://doi.org/10.1111/ectj.12097).\n",
     "\n",
     "Chiang, H. D., Kato K., Ma, Y. and Sasaki, Y. (2021), Multiway Cluster Robust Double/Debiased Machine Learning, Journal of Business & Economic Statistics, doi: [10.1080/07350015.2021.1895815](https://doi.org/10.1080/07350015.2021.1895815), arXiv: [1909.03489](https://arxiv.org/abs/1909.03489)."
-   ],
-   "metadata": {
-    "id": "NhIE_t-A1_ct"
-   }
+   ]
   }
  ],
  "metadata": {

--- a/doc/examples/r_double_ml_multiway_cluster.ipynb
+++ b/doc/examples/r_double_ml_multiway_cluster.ipynb
@@ -2,6 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "746b8a5d",
+   "metadata": {},
    "source": [
     "# R: Cluster Robust Double Machine Learning\n",
     "\n",
@@ -23,29 +25,31 @@
     "https://docs.doubleml.org/stable/guide/basics.html#sample-splitting-to-remove-bias-induced-by-overfitting) as well as to the explanation in [Chernozhukov et al. (2018)](https://doi.org/10.1111/ectj.12097) .\n",
     "\n",
     "In order to achieve independent data splits in a setting with one-way or multi-way clustering, [Chiang et al. (2021)](https://doi.org/10.1080/07350015.2021.1895815) develop an updated  $K$-fold sample splitting procedure that ensures independent sample splits: The data set is split into disjoint partitions in terms of all clustering dimensions. For example, in a situation with two-way clustering, the data is split into $K^2$ folds. The machine learning models are then trained on a specific fold and used for generation of predictions in hold-out samples. Thereby, the sample splitting procedure ensures that the hold-out samples do not contain observations of the same clusters as used for training."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "library('hdm')\r\n",
-    "library('DoubleML')\r\n",
-    "library('mlr3')\r\n",
-    "library('mlr3learners')\r\n",
-    "# surpress messages from mlr3 package during fitting\r\n",
-    "lgr::get_logger(\"mlr3\")$set_threshold(\"warn\")\r\n",
-    "\r\n",
-    "library('ggplot2')\r\n",
-    "library('reshape2')\r\n",
-    "library('gridExtra')"
-   ],
+   "id": "76984720",
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": [
+    "library('hdm')\n",
+    "library('DoubleML')\n",
+    "library('mlr3')\n",
+    "library('mlr3learners')\n",
+    "# surpress messages from mlr3 package during fitting\n",
+    "lgr::get_logger(\"mlr3\")$set_threshold(\"warn\")\n",
+    "\n",
+    "library('ggplot2')\n",
+    "library('reshape2')\n",
+    "library('gridExtra')"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "171f1458",
+   "metadata": {},
    "source": [
     "## A Motivating Example: Two-Way Cluster Robust DML\n",
     "\n",
@@ -62,11 +66,12 @@
     "Y_{ij} = D_{ij} \\theta_0 +  g_0(X_{ij}) + \\epsilon_{ij}, & &\\mathbb{E}(\\epsilon_{ij} | X_{ij}, Z_{ij}) = 0, \\\\\n",
     "Z_{ij} = m_0(X_{ij}) + v_{ij}, & &\\mathbb{E}(v_{ij} | X_{ij}) = 0.\n",
     "\\end{aligned}$$"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "349c3e43",
+   "metadata": {},
    "source": [
     "### Simulate two-way cluster data\n",
     "\n",
@@ -102,12 +107,14 @@
     "and $\\alpha_{ij}^V, \\alpha_{i}^V, \\alpha_{j}^V \\sim \\mathcal{N}(0, 1)$.\n",
     "\n",
     "Data from this DGP can be generated with the [make_pliv_multiway_cluster_CKMS2021()](https://docs.doubleml.org/r/stable/reference/make_pliv_multiway_cluster_CKMS2021.html) function from [DoubleML](https://docs.doubleml.org/stable/index.html)."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1f53686a",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Set the simulation parameters\n",
     "N = 25  # number of observations (first dimension)\n",
@@ -116,48 +123,53 @@
     "set.seed(3141) # set seed\n",
     "\n",
     "obj_dml_data = make_pliv_multiway_cluster_CKMS2021(N, M, dim_X)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "0ea047f4",
+   "metadata": {},
    "source": [
     "### Data-Backend for Cluster Data\n",
     "The implementation of cluster robust double machine learning is based on a special data-backend called [DoubleMLClusterData](https://docs.doubleml.org/r/stable/reference/DoubleMLClusterData.html). As compared to the standard data-backend [DoubleMLData](https://docs.doubleml.org/r/stable/reference/DoubleMLData.html), users can specify the clustering variables during instantiation of a  [DoubleMLClusterData](https://docs.doubleml.org/r/stable/reference/DoubleMLClusterData.html) object. The estimation framework will subsequently account for the provided clustering options."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "dc5ab7a6",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# The simulated data is of type DoubleMLClusterData\n",
     "print(obj_dml_data)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e3184de7",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# The cluster variables are part of the DataFrame\n",
     "head(obj_dml_data$data)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "983802bf",
+   "metadata": {},
    "source": [
     "### Initialize the objects of class `DoubleMLPLIV`"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "74cf6b1f",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Set machine learning methods for m, g & r\n",
     "ml_g = lrn(\"regr.cv_glmnet\", nfolds = 10, s = \"lambda.min\")\n",
@@ -168,40 +180,44 @@
     "dml_pliv_obj = DoubleMLPLIV$new(obj_dml_data,\n",
     "                                ml_g, ml_m, ml_r,\n",
     "                                n_folds=3)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c70d71fc",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print(dml_pliv_obj)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "41aa4acd",
+   "metadata": {},
    "source": [
     "### Define Helper Functions for Plotting"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "04e4a525",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "library(RColorBrewer)\n",
     "coul <- rev(colorRampPalette(brewer.pal(8, \"RdBu\"))(3))\n",
     "options(repr.plot.width = 10, repr.plot.height = 10)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7500c9ac",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "plt_smpls = function(smpls, n_folds) {\n",
     "    df = matrix(0, nrow = N*M, ncol = n_folds)\n",
@@ -212,61 +228,62 @@
     "\n",
     "    heatmap(df, Rowv=NA, Colv=NA, col=coul, cexRow=1.5, cexCol=1.5, scale='none')\n",
     "}"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "plt_smpls_cluster = function(smpls_cluster, n_folds, n_folds_per_cluster) {\r\n",
-    "    #options(repr.plot.width = 6, repr.plot.height = 6)\r\n",
-    "    plots = list()\r\n",
-    "    for (i_fold in 1:n_folds){\r\n",
-    "        mat = matrix(0, nrow = M, ncol = N)\r\n",
-    "        for (k in smpls_cluster$train_ids[[i_fold]][[1]]) {\r\n",
-    "            for (l in smpls_cluster$train_ids[[i_fold]][[2]]) {\r\n",
-    "                mat[k, l] = -1\r\n",
-    "            }\r\n",
-    "        }\r\n",
-    "        for (k in smpls_cluster$test_ids[[i_fold]][[1]]) {\r\n",
-    "            for (l in smpls_cluster$test_ids[[i_fold]][[2]]) {\r\n",
-    "                mat[k, l] = 1\r\n",
-    "            }\r\n",
-    "        }\r\n",
-    "        l = (i_fold-1) %% n_folds_per_cluster + 1\r\n",
-    "        k = ((i_fold-1) %/% n_folds_per_cluster)+1\r\n",
-    "        df = data.frame(mat)\r\n",
-    "        cols = names(df)\r\n",
-    "        names(df) = 1:N\r\n",
-    "        df$id = 1:N\r\n",
-    "        df_plot = melt(df,  id.var = 'id')\r\n",
-    "        df_plot$value = factor(df_plot$value)\r\n",
-    "        plots[[i_fold]] = ggplot(data = df_plot, aes(x=id, y=variable)) + \r\n",
-    "          geom_tile(aes(fill=value), colour = \"grey50\") +\r\n",
-    "        scale_fill_manual(values = c(\"darkblue\", \"white\", \"darkred\")) +\r\n",
-    "        theme(text = element_text(size=15))\r\n",
-    "        # ToDo: Add Subplot titles\r\n",
-    "        if (k == 3) {\r\n",
-    "            plots[[i_fold]] = plots[[i_fold]] + xlab(expression(paste('Second Cluster Variable ', l)))\r\n",
-    "        } else {\r\n",
-    "            plots[[i_fold]] = plots[[i_fold]] + xlab('')\r\n",
-    "        }\r\n",
-    "        if (l == 1) {\r\n",
-    "            plots[[i_fold]] = plots[[i_fold]] + ylab(expression(paste('First Cluster Variable ', k)))\r\n",
-    "        } else {\r\n",
-    "            plots[[i_fold]] = plots[[i_fold]] + ylab('')\r\n",
-    "        }\r\n",
-    "    }\r\n",
-    "    return(plots)\r\n",
-    "}"
-   ],
+   "id": "330d26df",
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": [
+    "plt_smpls_cluster = function(smpls_cluster, n_folds, n_folds_per_cluster) {\n",
+    "    #options(repr.plot.width = 6, repr.plot.height = 6)\n",
+    "    plots = list()\n",
+    "    for (i_fold in 1:n_folds){\n",
+    "        mat = matrix(0, nrow = M, ncol = N)\n",
+    "        for (k in smpls_cluster$train_ids[[i_fold]][[1]]) {\n",
+    "            for (l in smpls_cluster$train_ids[[i_fold]][[2]]) {\n",
+    "                mat[k, l] = -1\n",
+    "            }\n",
+    "        }\n",
+    "        for (k in smpls_cluster$test_ids[[i_fold]][[1]]) {\n",
+    "            for (l in smpls_cluster$test_ids[[i_fold]][[2]]) {\n",
+    "                mat[k, l] = 1\n",
+    "            }\n",
+    "        }\n",
+    "        l = (i_fold-1) %% n_folds_per_cluster + 1\n",
+    "        k = ((i_fold-1) %/% n_folds_per_cluster)+1\n",
+    "        df = data.frame(mat)\n",
+    "        cols = names(df)\n",
+    "        names(df) = 1:N\n",
+    "        df$id = 1:N\n",
+    "        df_plot = melt(df,  id.var = 'id')\n",
+    "        df_plot$value = factor(df_plot$value)\n",
+    "        plots[[i_fold]] = ggplot(data = df_plot, aes(x=id, y=variable)) + \n",
+    "          geom_tile(aes(fill=value), colour = \"grey50\") +\n",
+    "        scale_fill_manual(values = c(\"darkblue\", \"white\", \"darkred\")) +\n",
+    "        theme(text = element_text(size=15))\n",
+    "        # ToDo: Add Subplot titles\n",
+    "        if (k == 3) {\n",
+    "            plots[[i_fold]] = plots[[i_fold]] + xlab(expression(paste('Second Cluster Variable ', l)))\n",
+    "        } else {\n",
+    "            plots[[i_fold]] = plots[[i_fold]] + xlab('')\n",
+    "        }\n",
+    "        if (l == 1) {\n",
+    "            plots[[i_fold]] = plots[[i_fold]] + ylab(expression(paste('First Cluster Variable ', k)))\n",
+    "        } else {\n",
+    "            plots[[i_fold]] = plots[[i_fold]] + ylab('')\n",
+    "        }\n",
+    "    }\n",
+    "    return(plots)\n",
+    "}"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "76f4b841",
+   "metadata": {},
    "source": [
     "### Cluster Robust Cross Fitting\n",
     "A key element of cluster robust DML ([Chiang et al. 2021](https://doi.org/10.1080/07350015.2021.1895815)) is a special sample splitting used for the cross-fitting.\n",
@@ -286,64 +303,69 @@
     "$$\n",
     "for $\\tilde{\\theta}_0$.\n",
     "Here $|I_k|$ denotes the cardinality, i.e., the number of clusters in the $k$-th fold for the first cluster variable."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "8b3239eb",
+   "metadata": {},
    "source": [
     "We can visualize the sample splitting of the $N \\cdot M = 625$ observations into $K \\cdot K = 9$ folds. The following heat map illustrates the partitioned data set that is split into $K=9$ folds. The horizontal axis corresponds to the fold indices and the vertical axis to the indices of the observations. A blue field indicates that the observation $i$ is used for fitting the nuisance part, red indicates that the fold is used for prediction generation and white means that an observation is left out from the sample splitting. \n",
     "\n",
     "For example, the first observation as displayed on the very bottom of the figure is used for training of the nuisance parts in the first, second, fourth and fifth fold and used for generation of the predictions in fold nine. At the same time the observation is left out from the sample splitting procedure in folds three, six, seven and eight."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6de28e86",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "plt_smpls(dml_pliv_obj$smpls[[1]], dml_pliv_obj$n_folds)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "73cfaae5",
+   "metadata": {},
    "source": [
-    "If we visualize the sample splitting in terms of the cluster variables, the partitioning of the data into $9$ folds $I_k \\times J_\\ell$ becomes clear.\r\n",
-    "The identifiers for the first cluster variable $[N]:=\\{1,\\ldots,N\\}$ have been randomly partioned into $K=3$ folds denoted by $\\{I_1, I_2, I_3\\}$ and the identifiers for the second cluster variable $[M]:=\\{1,\\ldots,M\\}$ have also been randomly partioned into $K=3$ folds denoted by $\\{J_1, J_2, J_3\\}$.\r\n",
-    "By considering every combination $I_k \\times J_\\ell$ for $1 \\leq k, \\ell \\leq K = 3$ we effectively base the cross-fitting on $9$ folds.\r\n",
-    "\r\n",
-    "We now want to focus on the top-left sub-plot showing the partitioning of the cluster data for the first fold.\r\n",
-    "The $x$-axis corresponds to the first cluster variable and the $y$-axis to the second cluster variable.\r\n",
-    "Observations with cluster variables $(i,j) \\in I_K \\times J_\\ell$ are used for estimation of the target parameter $\\tilde{\\theta}_0$ by solving a Neyman orthogonal score function.\r\n",
-    "For estimation of the nuisance function, we only use observation where neither the first cluster variable is in $I_K$ nor the second cluster variable is in $J_\\ell$, i.e., we use observations indexed by $(i,j)\\in ([N]\\setminus I_K) \\times ([M]\\setminus J_\\ell)$ to estimate the nuisance functions\r\n",
-    "$$\r\n",
-    "\\hat{\\eta}_{k\\ell} = \\hat{\\eta}\\left((W_{ij})_{(i,j)\\in ([N]\\setminus I_K) \\times ([M]\\setminus J_\\ell)}\\right).\r\n",
-    "$$\r\n",
+    "If we visualize the sample splitting in terms of the cluster variables, the partitioning of the data into $9$ folds $I_k \\times J_\\ell$ becomes clear.\n",
+    "The identifiers for the first cluster variable $[N]:=\\{1,\\ldots,N\\}$ have been randomly partioned into $K=3$ folds denoted by $\\{I_1, I_2, I_3\\}$ and the identifiers for the second cluster variable $[M]:=\\{1,\\ldots,M\\}$ have also been randomly partioned into $K=3$ folds denoted by $\\{J_1, J_2, J_3\\}$.\n",
+    "By considering every combination $I_k \\times J_\\ell$ for $1 \\leq k, \\ell \\leq K = 3$ we effectively base the cross-fitting on $9$ folds.\n",
+    "\n",
+    "We now want to focus on the top-left sub-plot showing the partitioning of the cluster data for the first fold.\n",
+    "The $x$-axis corresponds to the first cluster variable and the $y$-axis to the second cluster variable.\n",
+    "Observations with cluster variables $(i,j) \\in I_K \\times J_\\ell$ are used for estimation of the target parameter $\\tilde{\\theta}_0$ by solving a Neyman orthogonal score function.\n",
+    "For estimation of the nuisance function, we only use observation where neither the first cluster variable is in $I_K$ nor the second cluster variable is in $J_\\ell$, i.e., we use observations indexed by $(i,j)\\in ([N]\\setminus I_K) \\times ([M]\\setminus J_\\ell)$ to estimate the nuisance functions\n",
+    "$$\n",
+    "\\hat{\\eta}_{k\\ell} = \\hat{\\eta}\\left((W_{ij})_{(i,j)\\in ([N]\\setminus I_K) \\times ([M]\\setminus J_\\ell)}\\right).\n",
+    "$$\n",
     "This way we guarantee that there are never observations from the same cluster (first and/or second cluster dimension) in the sample for the nuisance function estimation (blue) and at the same time in the sample for solving the score function (red). As a result of this special sample splitting proposed by [Chiang et al. (2021)](https://doi.org/10.1080/07350015.2021.1895815), the observations in the score (red) and nuisance (blue) sample can be considered independent and the standard cross-fitting approach for double machine learning can be applied."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "options(repr.plot.width = 12, repr.plot.height = 10)\r\n",
-    "plots = plt_smpls_cluster(dml_pliv_obj$smpls_cluster[[1]],\r\n",
-    "                         dml_pliv_obj$n_folds,\r\n",
-    "                         sqrt(dml_pliv_obj$n_folds))\r\n",
-    "grid.arrange(grobs=plots, ncol = 3, nrow = 3)"
-   ],
-   "outputs": [],
+   "id": "8674ef61",
    "metadata": {
     "tags": [
      "nbsphinx-thumbnail"
     ]
-   }
+   },
+   "outputs": [],
+   "source": [
+    "options(repr.plot.width = 12, repr.plot.height = 10)\n",
+    "plots = plt_smpls_cluster(dml_pliv_obj$smpls_cluster[[1]],\n",
+    "                         dml_pliv_obj$n_folds,\n",
+    "                         sqrt(dml_pliv_obj$n_folds))\n",
+    "grid.arrange(grobs=plots, ncol = 3, nrow = 3)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "f4fad944",
+   "metadata": {},
    "source": [
     "### Cluster Robust Standard Errors\n",
     "In the abstract base class `DoubleML` the estimation of cluster robust standard errors is implemented for all supported double machine learning models.\n",
@@ -384,22 +406,24 @@
     "\\end{aligned}\n",
     "$$\n",
     "with $\\underline{C} = N \\wedge M$."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "# Estimate the PLIV model with cluster robust double machine learning\r\n",
-    "dml_pliv_obj$fit()\r\n",
-    "dml_pliv_obj$summary()"
-   ],
+   "id": "23a031d1",
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": [
+    "# Estimate the PLIV model with cluster robust double machine learning\n",
+    "dml_pliv_obj$fit()\n",
+    "dml_pliv_obj$summary()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "dae66229",
+   "metadata": {},
    "source": [
     "## (One-Way) Cluster Robust Double Machine Learing\n",
     "\n",
@@ -409,35 +433,39 @@
     "\\omega_2^X = \\omega_2^\\varepsilon = \\omega_2^v = \\omega_2^V = 0.\n",
     "$$\n",
     "Again we can simulate this data with [make_pliv_multiway_cluster_CKMS2021()](https://docs.doubleml.org/r/stable/reference/make_pliv_multiway_cluster_CKMS2021.html). To prepare the data-backend for one-way clustering, we only have to alter the `cluster_cols` to be `'cluster_var_i'`."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "obj_dml_data = make_pliv_multiway_cluster_CKMS2021(N, M, dim_X,\r\n",
-    "                                                   omega_X = c(0.25, 0),\r\n",
-    "                                                   omega_epsilon = c(0.25, 0),\r\n",
-    "                                                   omega_v = c(0.25, 0),\r\n",
-    "                                                   omega_V = c(0.25, 0))"
-   ],
+   "id": "62076b01",
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": [
+    "obj_dml_data = make_pliv_multiway_cluster_CKMS2021(N, M, dim_X,\n",
+    "                                                   omega_X = c(0.25, 0),\n",
+    "                                                   omega_epsilon = c(0.25, 0),\n",
+    "                                                   omega_v = c(0.25, 0),\n",
+    "                                                   omega_V = c(0.25, 0))"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b818119b",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "obj_dml_data$cluster_cols = 'cluster_var_i'\n",
     "print(obj_dml_data)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "29cace52",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Set machine learning methods for m, g & r\n",
     "ml_g = lrn(\"regr.cv_glmnet\", nfolds = 10, s = \"lambda.min\")\n",
@@ -448,74 +476,81 @@
     "dml_pliv_obj = DoubleMLPLIV$new(obj_dml_data,\n",
     "                                ml_g, ml_m, ml_r,\n",
     "                                n_folds=3)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "94a58a15",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "dml_pliv_obj$fit()\n",
     "dml_pliv_obj$summary()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "a5901bc2",
+   "metadata": {},
    "source": [
     "## Real-Data Application\n",
     "As a real-data application we revist the consumer demand example from [Chiang et al. (2021)](https://doi.org/10.1080/07350015.2021.1895815).\n",
     "The U.S. automobile data of [Berry, Levinsohn, and Pakes (1995)](https://doi.org/10.2307/2171802) is obtained from the `R` package [hdm](https://cran.r-project.org/web/packages/hdm/index.html). In this example, we consider different specifications for the cluster dimensions."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "5d103ae5",
+   "metadata": {},
    "source": [
     "### Load and Process Data"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "97f0c9fe",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "## Prepare the BLP data\n",
     "data(BLP);\n",
     "blp_data <- BLP$BLP;\n",
     "blp_data$price <- blp_data$price + 11.761\n",
     "blp_data$log_p = log(blp_data$price)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5924f423",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "x_cols = c('hpwt', 'air', 'mpd', 'space')\n",
     "head(blp_data[x_cols])"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "01411d79",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "iv_vars = as.data.frame(hdm:::constructIV(blp_data$firm.id,\n",
     "                            blp_data$cdid,\n",
     "                            blp_data$id,\n",
     "                            blp_data[x_cols]))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fa28c802",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "formula = formula(paste0(\" ~ -1 + (hpwt + air + mpd + space)^2\",\n",
     "                         \"+ I(hpwt^2)*(air + mpd + space)\",\n",
@@ -525,44 +560,48 @@
     "                         \"+ I(space^2) + I(hpwt^3) + I(air^3) + I(mpd^3) + I(space^3)\"))\n",
     "data_transf = data.frame(model.matrix(formula, blp_data))\n",
     "names(data_transf)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5a2b5397",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "y_col = 'y'\n",
     "d_col = 'log_p'\n",
     "cluster_cols = c('model.id', 'cdid')\n",
     "all_z_cols = c('sum.other.hpwt', 'sum.other.mpd', 'sum.other.space')\n",
     "z_col = all_z_cols[1]"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2b945460",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "dml_df = cbind(blp_data[c(y_col, d_col, cluster_cols)],\n",
     "               data_transf,\n",
     "               iv_vars[all_z_cols])"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "6e06f4e7",
+   "metadata": {},
    "source": [
     "### Initialize `DoubleMLClusterData` object"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "34d05896",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "dml_data = DoubleMLClusterData$new(dml_df,\n",
     "                                   y_col=y_col,\n",
@@ -570,51 +609,56 @@
     "                                   z_cols=z_col,\n",
     "                                   cluster_cols=cluster_cols,\n",
     "                                   x_cols=names(data_transf))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4e1f8477",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print(dml_data)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "433a0193",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "lasso = lrn(\"regr.cv_glmnet\", nfolds = 10, s = \"lambda.min\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "57378194",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "coef_df = data.frame(matrix(NA_real_, ncol = 4, nrow = 1))\n",
     "colnames(coef_df) = c('zero-way', 'one-way-product', 'one-way-market', 'two-way')\n",
     "rownames(coef_df) = all_z_cols[1]\n",
     "se_df = coef_df\n",
     "n_rep = 10"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "f859db86",
+   "metadata": {},
    "source": [
     "### Two-Way Clustering with Respect to Product and Market"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b6648ff4",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "set.seed(1111)\n",
     "dml_data$z_cols = z_col\n",
@@ -625,20 +669,22 @@
     "dml_pliv$fit()\n",
     "coef_df[1, 4] = dml_pliv$coef\n",
     "se_df[1, 4] = dml_pliv$se"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1c7652f1",
+   "metadata": {},
    "source": [
     "### One-Way Clustering with Respect to the Product"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "569f621d",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "set.seed(2222)\n",
     "dml_data$z_cols = z_col\n",
@@ -649,20 +695,22 @@
     "dml_pliv$fit()\n",
     "coef_df[1, 2] = dml_pliv$coef\n",
     "se_df[1, 2] = dml_pliv$se"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "729ea1f8",
+   "metadata": {},
    "source": [
     "### One-Way Clustering with Respect to the Market"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "dcb8c14c",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "set.seed(3333)\n",
     "dml_data$z_cols = z_col\n",
@@ -673,42 +721,46 @@
     "dml_pliv$fit()\n",
     "coef_df[1, 3] = dml_pliv$coef\n",
     "se_df[1, 3] = dml_pliv$se"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "99463f43",
+   "metadata": {},
    "source": [
     "### No Clustering / Zero-Way Clustering"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "854596e4",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "dml_data = DoubleMLData$new(dml_df,\n",
     "                            y_col=y_col,\n",
     "                            d_cols=d_col,\n",
     "                            z_cols=z_col,\n",
     "                            x_cols=names(data_transf))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9998f02f",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print(dml_data)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9b76db04",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "set.seed(4444)\n",
     "dml_data$z_cols = z_col\n",
@@ -718,37 +770,40 @@
     "dml_pliv$fit()\n",
     "coef_df[1, 1] = dml_pliv$coef\n",
     "se_df[1, 1] = dml_pliv$se"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "3f71db0a",
+   "metadata": {},
    "source": [
     "### Application Results"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d9112d98",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "coef_df"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f98544f5",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "se_df"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ca8e628b",
+   "metadata": {},
    "source": [
     "## References\n",
     "Berry, S., Levinsohn, J., and Pakes, A. (1995), Automobile Prices in Market\n",
@@ -759,8 +814,7 @@
     "Chernozhukov, V., Chetverikov, D., Demirer, M., Duflo, E., Hansen, C., Newey, W. and Robins, J. (2018), Double/debiased machine learning for treatment and structural parameters. The Econometrics Journal, 21: C1-C68, doi: [10.1111/ectj.12097](https://doi.org/10.1111/ectj.12097).\n",
     "\n",
     "Chiang, H. D., Kato K., Ma, Y. and Sasaki, Y. (2021), Multiway Cluster Robust Double/Debiased Machine Learning, Journal of Business & Economic Statistics, doi: [10.1080/07350015.2021.1895815](https://doi.org/10.1080/07350015.2021.1895815), arXiv: [1909.03489](https://arxiv.org/abs/1909.03489)."
-   ],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Looks like GitHub Codespaces introduced those `\r`'s (see https://github.com/DoubleML/doubleml-docs/commit/5f1ea6cf1c6992bf2ff1a5df0234c2c950efc7c0) which caused the builds to fail.