### PR TITLE
As a temporary fix for #45 use scikit-learn < 1.0.0 for building the documentation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+scikit-learn<1.0.0
 DoubleML
 
 # test


### PR DESCRIPTION
This is a temporary fix for #45 in order to be able to build the docu again.