### PR TITLE
Split GitHub Action Workflows in Deploy and Test

### DIFF
--- a/.github/workflows/deploy_docu_dev.yml
+++ b/.github/workflows/deploy_docu_dev.yml
@@ -7,17 +7,6 @@ on:
     branches:
       - master
   workflow_dispatch:
-    inputs:
-      doubleml-py-branch:
-        description: 'Branch in https://github.com/DoubleML/doubleml-for-py'
-        required: true
-        default: 'master'
-      doubleml-r-branch:
-        description: 'Branch in https://github.com/DoubleML/doubleml-for-r'
-        required: true
-        default: 'master'
-  schedule:
-    - cron: "0 9 * * 1,3,5"
 
 
 jobs:
@@ -32,19 +21,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Check out the repo containing the python pkg DoubleML (dev)
-      if: ${{ github.event_name != 'workflow_dispatch' }}
       uses: actions/checkout@v2
       with:
         repository: DoubleML/doubleml-for-py
         path: doubleml-for-py
-
-    - name: Check out the repo containing the python pkg DoubleML (dev)
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      uses: actions/checkout@v2
-      with:
-        repository: DoubleML/doubleml-for-py
-        path: doubleml-for-py
-        ref: ${{ github.event.inputs.doubleml-py-branch }}
 
     - name: Install SSH Client for deploying the docu to github pages
       uses: webfactory/ssh-agent@v0.4.1
@@ -95,19 +75,9 @@ jobs:
         key: doubleml-user-guide-dev-${{ hashFiles('.github/R-version') }}
 
     - name: Install R kernel for Jupyter and the R package DoubleML (dev)
-      if: ${{ github.event_name != 'workflow_dispatch' }}
       run: |
         install.packages('remotes')
         remotes::install_github('DoubleML/doubleml-for-r', dependencies = TRUE)
-        install.packages(c('ggplot2', 'IRkernel', 'xgboost', 'hdm', 'reshape2', 'gridExtra', "igraph", "mlr3filters"))
-        IRkernel::installspec()
-      shell: Rscript {0}
-
-    - name: Install R kernel for Jupyter and the R package DoubleML (dev)
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      run: |
-        install.packages('remotes')
-        remotes::install_github('DoubleML/doubleml-for-r@${{ github.event.inputs.doubleml-r-branch }}', dependencies = TRUE)
         install.packages(c('ggplot2', 'IRkernel', 'xgboost', 'hdm', 'reshape2', 'gridExtra', "igraph", "mlr3filters"))
         IRkernel::installspec()
       shell: Rscript {0}

--- a/.github/workflows/test_build_docu_dev.yml
+++ b/.github/workflows/test_build_docu_dev.yml
@@ -1,0 +1,121 @@
+# Workflow based on https://github.com/actions/starter-workflows/blob/main/ci/python-package.yml
+
+name: Test Docu Build (with dev Pkgs)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      doubleml-py-branch:
+        description: 'Branch in https://github.com/DoubleML/doubleml-for-py'
+        required: true
+        default: 'master'
+      doubleml-r-branch:
+        description: 'Branch in https://github.com/DoubleML/doubleml-for-r'
+        required: true
+        default: 'master'
+  schedule:
+    - cron: "0 9 * * 1,3,5"
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+    - name: Check out the repo containing the docu source
+      uses: actions/checkout@v2
+
+    - name: Check out the repo containing the python pkg DoubleML (dev)
+      if: ${{ github.event_name != 'workflow_dispatch' }}
+      uses: actions/checkout@v2
+      with:
+        repository: DoubleML/doubleml-for-py
+        path: doubleml-for-py
+
+    - name: Check out the repo containing the python pkg DoubleML (dev)
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      uses: actions/checkout@v2
+      with:
+        repository: DoubleML/doubleml-for-py
+        path: doubleml-for-py
+        ref: ${{ github.event.inputs.doubleml-py-branch }}
+
+    - name: Install graphviz
+      run: sudo apt-get install graphviz
+
+    - name: Install python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install dependencies and the python package
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip uninstall -y DoubleML
+        cd doubleml-for-py
+        pip install -e .
+
+    - name: Add R repository
+      run: |
+        sudo apt install dirmngr gnupg apt-transport-https ca-certificates software-properties-common
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+        sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/'
+    - name: Install R
+      run: |
+        sudo apt-get update
+        sudo apt-get install r-base
+        sudo apt-get install r-base-dev
+        sudo apt-get install -y zlib1g-dev libicu-dev pandoc make libcurl4-openssl-dev libssl-dev
+
+    - name: Get user library folder
+      run: |
+        mkdir ${GITHUB_WORKSPACE}/tmp_r_libs_user
+        echo R_LIBS_USER=${GITHUB_WORKSPACE}/tmp_r_libs_user >> $GITHUB_ENV
+
+    - name: Query R version
+      run: |
+        writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+      shell: Rscript {0}
+
+    - name: Cache R packages
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.R_LIBS_USER }}
+        key: doubleml-test-build-dev-${{ hashFiles('.github/R-version') }}
+
+    - name: Install R kernel for Jupyter and the R package DoubleML (dev)
+      if: ${{ github.event_name != 'workflow_dispatch' }}
+      run: |
+        install.packages('remotes')
+        remotes::install_github('DoubleML/doubleml-for-r', dependencies = TRUE)
+        install.packages(c('ggplot2', 'IRkernel', 'xgboost', 'hdm', 'reshape2', 'gridExtra', "igraph", "mlr3filters"))
+        IRkernel::installspec()
+      shell: Rscript {0}
+
+    - name: Install R kernel for Jupyter and the R package DoubleML (dev)
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      run: |
+        install.packages('remotes')
+        remotes::install_github('DoubleML/doubleml-for-r@${{ github.event.inputs.doubleml-r-branch }}', dependencies = TRUE)
+        install.packages(c('ggplot2', 'IRkernel', 'xgboost', 'hdm', 'reshape2', 'gridExtra', "igraph", "mlr3filters"))
+        IRkernel::installspec()
+      shell: Rscript {0}
+
+    - name: Build docu with sphinx
+      run: |
+        make -C doc html # build docu
+
+    - name: Upload html artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: build_html
+        path: doc/_build/html/

--- a/.github/workflows/test_build_docu_dev.yml
+++ b/.github/workflows/test_build_docu_dev.yml
@@ -116,7 +116,7 @@ jobs:
 
     - name: Check for broken links / URLs
       run: |
-        make -b linkcheck
+        make -C doc linkcheck
 
     - name: Upload html artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/test_build_docu_dev.yml
+++ b/.github/workflows/test_build_docu_dev.yml
@@ -116,7 +116,7 @@ jobs:
 
     - name: Check for broken links / URLs
       run: |
-        make linkcheck
+        make -b linkcheck
 
     - name: Upload html artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/test_build_docu_dev.yml
+++ b/.github/workflows/test_build_docu_dev.yml
@@ -114,6 +114,10 @@ jobs:
       run: |
         make -C doc html # build docu
 
+    - name: Check for broken links / URLs
+      run: |
+        make linkcheck
+
     - name: Upload html artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/test_build_docu_released.yml
+++ b/.github/workflows/test_build_docu_released.yml
@@ -75,6 +75,10 @@ jobs:
       run: |
         make -C doc html # build docu
 
+    - name: Check for broken links / URLs
+      run: |
+        make linkcheck
+
     - name: Upload html artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/test_build_docu_released.yml
+++ b/.github/workflows/test_build_docu_released.yml
@@ -1,6 +1,6 @@
 # Workflow based on https://github.com/actions/starter-workflows/blob/main/ci/python-package.yml
 
-name: Test Docu Build (with dev pkgs)
+name: Test Docu Build (with released pkgs)
 
 on:
   push:
@@ -10,15 +10,6 @@ on:
     branches:
       - master
   workflow_dispatch:
-    inputs:
-      doubleml-py-branch:
-        description: 'Branch in https://github.com/DoubleML/doubleml-for-py'
-        required: true
-        default: 'master'
-      doubleml-r-branch:
-        description: 'Branch in https://github.com/DoubleML/doubleml-for-r'
-        required: true
-        default: 'master'
   schedule:
     - cron: "0 9 * * 1,3,5"
 
@@ -27,27 +18,10 @@ jobs:
   build:
 
     runs-on: ubuntu-20.04
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
     - name: Check out the repo containing the docu source
       uses: actions/checkout@v2
-
-    - name: Check out the repo containing the python pkg DoubleML (dev)
-      if: ${{ github.event_name != 'workflow_dispatch' }}
-      uses: actions/checkout@v2
-      with:
-        repository: DoubleML/doubleml-for-py
-        path: doubleml-for-py
-
-    - name: Check out the repo containing the python pkg DoubleML (dev)
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      uses: actions/checkout@v2
-      with:
-        repository: DoubleML/doubleml-for-py
-        path: doubleml-for-py
-        ref: ${{ github.event.inputs.doubleml-py-branch }}
 
     - name: Install graphviz
       run: sudo apt-get install graphviz
@@ -60,9 +34,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip uninstall -y DoubleML
-        cd doubleml-for-py
-        pip install -e .
 
     - name: Add R repository
       run: |
@@ -90,22 +61,12 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.R_LIBS_USER }}
-        key: doubleml-test-build-dev-${{ hashFiles('.github/R-version') }}
+        key: doubleml-test-build-stable-${{ hashFiles('.github/R-version') }}
 
     - name: Install R kernel for Jupyter and the R package DoubleML (dev)
-      if: ${{ github.event_name != 'workflow_dispatch' }}
       run: |
         install.packages('remotes')
-        remotes::install_github('DoubleML/doubleml-for-r', dependencies = TRUE)
-        install.packages(c('ggplot2', 'IRkernel', 'xgboost', 'hdm', 'reshape2', 'gridExtra', "igraph", "mlr3filters"))
-        IRkernel::installspec()
-      shell: Rscript {0}
-
-    - name: Install R kernel for Jupyter and the R package DoubleML (dev)
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      run: |
-        install.packages('remotes')
-        remotes::install_github('DoubleML/doubleml-for-r@${{ github.event.inputs.doubleml-r-branch }}', dependencies = TRUE)
+        remotes::install_cran('DoubleML', dependencies = TRUE)
         install.packages(c('ggplot2', 'IRkernel', 'xgboost', 'hdm', 'reshape2', 'gridExtra', "igraph", "mlr3filters"))
         IRkernel::installspec()
       shell: Rscript {0}

--- a/.github/workflows/test_build_docu_released.yml
+++ b/.github/workflows/test_build_docu_released.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Check for broken links / URLs
       run: |
-        make linkcheck
+        make -b linkcheck
 
     - name: Upload html artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/test_build_docu_released.yml
+++ b/.github/workflows/test_build_docu_released.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Check for broken links / URLs
       run: |
-        make -b linkcheck
+        make -C doc linkcheck
 
     - name: Upload html artifacts
       uses: actions/upload-artifact@v2

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -125,6 +125,12 @@ intersphinx_mapping = {
     'statsmodels': ('https://www.statsmodels.org/stable/', None),
 }
 
+linkcheck_ignore = [
+    'https://doi.org/10.1093/ectj/utaa001',  # Valid DOI; Causes 403 Client Error: Forbidden for url:...
+    'https://doi.org/10.1111/ectj.12097',  # Valid DOI; Causes 403 Client Error: Forbidden for url:...
+    'https://doi.org/10.2307/2171802',  # Valid DOI; Causes 403 Client Error: Forbidden for url:...
+]
+
 # To execute R code via jupyter-execute one needs to install the R kernel for jupyter
 # https://github.com/IRkernel/IRkernel
 

--- a/doc/guide/learners.rst
+++ b/doc/guide/learners.rst
@@ -501,7 +501,7 @@ parameters ``mtry`` and ``max.depth`` of a random forest. Evaluation is based on
 References
 ++++++++++
 
-* Lang, M., Binder, M., Richter, J., Schratz, P., Pfisterer, F., Coors, S., Au, Q., Casalicchio, G., Kotthoff, L., Bischl, B. (2019), mlr3: A modern object-oriented machine learing framework in R. Journal of Open Source Software, `doi:10.21105/joss.01903 <(doi:10.21105/joss.01903)[10.21105/joss.01903]>`_.
+* Lang, M., Binder, M., Richter, J., Schratz, P., Pfisterer, F., Coors, S., Au, Q., Casalicchio, G., Kotthoff, L., Bischl, B. (2019), mlr3: A modern object-oriented machine learing framework in R. Journal of Open Source Software, `doi:10.21105/joss.01903 <https://doi.org/10.21105/joss.01903>`_.
 
 * Becker, M., Binder, M., Bischl, B., Lang, M., Pfisterer, F., Reich, N.G., Richter, J., Schratz, P., Sonabend, R. (2020), mlr3 book, available at `https://mlr3book.mlr-org.com <https://mlr3book.mlr-org.com>`_.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -234,7 +234,7 @@ Chernozhukov, V., Chetverikov, D., Demirer, M., Duflo, E., Hansen, C., Newey, W.
 Double/debiased machine learning for treatment and structural parameters. The Econometrics Journal, 21: C1-C68, doi:`10.1111/ectj.12097 <https://doi.org/10.1111/ectj.12097>`_.
 
 Lang, M., Binder, M., Richter, J., Schratz, P., Pfisterer, F., Coors, S., Au, Q., Casalicchio, G., Kotthoff, L. and Bischl, B. (2019),
-mlr3: A modern object-oriented machine learing framework in R. Journal of Open Source Software, doi:`10.21105/joss.01903 <https://10.21105/joss.01903>`_.
+mlr3: A modern object-oriented machine learing framework in R. Journal of Open Source Software, doi:`10.21105/joss.01903 <https://doi.org/10.21105/joss.01903>`_.
 
 Pedregosa, F., Varoquaux, G., Gramfort, A., Michel, V., Thirion, B., Grisel, O., Blondel, M., Prettenhofer, P., Weiss, R., Dubourg, V., Vanderplas, J., Passos, A., Cournapeau, D., Brucher, M., Perrot, M. and Duchesnay, E. (2011),
 Scikit-learn: Machine Learning in Python. Journal of Machine Learning Research, 12: 2825--2830, `https://jmlr.csail.mit.edu/papers/v12/pedregosa11a.html <https://jmlr.csail.mit.edu/papers/v12/pedregosa11a.html>`_.

--- a/doc/intro/install.rst
+++ b/doc/intro/install.rst
@@ -130,7 +130,7 @@ Python: Installing the latest release from pip or conda
     .. dropdown:: pip with virtual environment
         :open:
 
-        Install Python 3 using ``brew install python`` or from `<https://www.python.org/downloads/mac-osx/>`_.
+        Install Python 3 using ``brew install python`` or from `<https://www.python.org/downloads/macos/>`_.
 
         To avoid potential conflicts with other packages it is recommended to use a virtual environment.
         We setup a virtual environment named ``dml-venv`` and activate it

--- a/doc/intro/intro.rst
+++ b/doc/intro/intro.rst
@@ -218,6 +218,6 @@ statistical inference like ``bootstrap()``, ``confint()`` and ``p_adjust()``, fo
 References
 ++++++++++
 
-* Lang, M., Binder, M., Richter, J., Schratz, P., Pfisterer, F., Coors, S., Au, Q., Casalicchio, G., Kotthoff, L., Bischl, B. (2019), mlr3: A modern object-oriented machine learing framework in R. Journal of Open Source Software, `doi:10.21105/joss.01903 <(doi:10.21105/joss.01903)[10.21105/joss.01903]>`_.
+* Lang, M., Binder, M., Richter, J., Schratz, P., Pfisterer, F., Coors, S., Au, Q., Casalicchio, G., Kotthoff, L., Bischl, B. (2019), mlr3: A modern object-oriented machine learing framework in R. Journal of Open Source Software, `doi:10.21105/joss.01903 <https://doi.org/10.21105/joss.01903>`_.
 * Pedregosa, F., Varoquaux, G., Gramfort, A., Michel, V., Thirion, B., Grisel, O., Blondel, M., Prettenhofer, P., Weiss, R., Dubourg, V., Vanderplas, J., Passos, A., Cournapeau, D., Brucher, M., Perrot, M. and Duchesnay, E. (2011), Scikit-learn: Machine Learning in Python. Journal of Machine Learning Research, 12: 2825--2830, `https://jmlr.csail.mit.edu/papers/v12/pedregosa11a.html <https://jmlr.csail.mit.edu/papers/v12/pedregosa11a.html>`_.
 

--- a/doc/literature/literature.rst
+++ b/doc/literature/literature.rst
@@ -94,7 +94,7 @@ Double machine learning literature
         - Neng-Chieh Chang |br|
           **Double/debiased machine learning for difference-in-differences models** |br|
           *The Econometrics Journal, 23(2), Pages 177–191, 2020* |br|
-          :opticon:`link` :link-badge:`https://academic.oup.com/ectj/article/23/2/177/5722119,"URL",cls=badge-dark`
+          :opticon:`link` :link-badge:`https://doi.org/10.1093/ectj/utaa001,"URL",cls=badge-dark`
           |hr|
 
         - Harold D. Chiang, Kengo Kato, Yukun Ma, Yuya Sasaki |br|

--- a/doc/release/release.rst
+++ b/doc/release/release.rst
@@ -33,7 +33,7 @@ Release notes
     **DoubleML 0.3.0**
 
     - Always use the same bootstrap algorithm independent of ``dml1`` vs ``dml2`` and consistent with docu and paper
-      `#101 <https://github.com/DoubleML/doubleml-for-py/pull/101>`_ &
+      `#101 <https://github.com/DoubleML/doubleml-for-py/issues/101>`_ &
       `#102 <https://github.com/DoubleML/doubleml-for-py/pull/102>`_
     - Added an exception handling to assure that an IV variable is specified when using a PLIV or IIVM model
       `#107 <https://github.com/DoubleML/doubleml-for-py/pull/107>`_
@@ -53,15 +53,15 @@ Release notes
     - IIVM model: Added a subgroups option to adapt to cases with and without the subgroups of always-takers and
       never-takers (`#96 <https://github.com/DoubleML/doubleml-for-py/pull/96>`_).
     - Add checks for the intersections of ``y_col``, ``d_cols``, ``x_cols``, ``z_cols``
-      (`#84 <https://github.com/DoubleML/doubleml-for-py/pull/84>`_,
+      (`#84 <https://github.com/DoubleML/doubleml-for-py/issues/84>`_,
       `#97 <https://github.com/DoubleML/doubleml-for-py/pull/97>`_).
-      This also fixes `#83 <https://github.com/DoubleML/doubleml-for-py/pull/83>`_ (with intersection
+      This also fixes `#83 <https://github.com/DoubleML/doubleml-for-py/issues/83>`_ (with intersection
       between ``x_cols`` and ``d_cols`` a column could have been added multiple times to the covariate matrix).
     - Added checks and exception handling for duplicate entries in ``d_cols``, ``x_cols`` or ``z_cols``
       (`#100 <https://github.com/DoubleML/doubleml-for-py/pull/100>`_).
     - Check the datatype of ``data`` when initializing ``DoubleMLData`` objects. Also check for duplicate column names
       (`#100 <https://github.com/DoubleML/doubleml-for-py/pull/100>`_).
-    - Fix bug `#95 <https://github.com/DoubleML/doubleml-for-py/pull/95>`_
+    - Fix bug `#95 <https://github.com/DoubleML/doubleml-for-py/issues/95>`_
       in `#97 <https://github.com/DoubleML/doubleml-for-py/pull/97>`_: It occurred when ``x_cols`` where inferred via
       setdiff and ``y_col`` was a string with multiple characters.
     - We updated the citation info to refer to the arXiv paper
@@ -162,28 +162,28 @@ Release notes
 
     - Use active bindings in the R6 OOP implementation
       `#106 <https://github.com/DoubleML/doubleml-for-r/pull/106>`_ &
-      `#93 <https://github.com/DoubleML/doubleml-for-r/pull/93>`_
+      `#93 <https://github.com/DoubleML/doubleml-for-r/issues/93>`_
     - Fix the aggregation formula for standard errors from repeated cross-fitting
-      `#94 <https://github.com/DoubleML/doubleml-for-r/pull/94>`_ &
+      `#94 <https://github.com/DoubleML/doubleml-for-r/issues/94>`_ &
       `#95 <https://github.com/DoubleML/doubleml-for-r/pull/95>`_
     - Always use the same bootstrap algorithm independent of ``dml1`` vs ``dml2`` and consistent with docu and paper
-      `#98 <https://github.com/DoubleML/doubleml-for-r/pull/98>`_ &
+      `#98 <https://github.com/DoubleML/doubleml-for-r/issues/98>`_ &
       `#99 <https://github.com/DoubleML/doubleml-for-r/pull/99>`_
     - Initialize predictions with NA and make sure that there are no misleading entries in the evaluated score
-      functions `#96 <https://github.com/DoubleML/doubleml-for-r/pull/96>`_ &
+      functions `#96 <https://github.com/DoubleML/doubleml-for-r/issues/96>`_ &
       `#105 <https://github.com/DoubleML/doubleml-for-r/pull/105>`_
     - Avoid overriding learner parameters during tuning
-      `#83 <https://github.com/DoubleML/doubleml-for-r/pull/83>`_ &
+      `#83 <https://github.com/DoubleML/doubleml-for-r/issues/83>`_ &
       `#84 <https://github.com/DoubleML/doubleml-for-r/pull/84>`_
     - Fixes in the exception handling and extension of the unit tests for the score function choice
       `#82 <https://github.com/DoubleML/doubleml-for-r/pull/82>`_
     - Prevent overwriting parameters from initialization when calling set_ml_nuisance_params
-      `#87 <https://github.com/DoubleML/doubleml-for-r/pull/87>`_ &
+      `#87 <https://github.com/DoubleML/doubleml-for-r/issues/87>`_ &
       `#89 <https://github.com/DoubleML/doubleml-for-r/pull/89>`_
     - Major refactoring and cleanup and extension of the unit test framework
       `#101 <https://github.com/DoubleML/doubleml-for-r/pull/101>`_
     - Extension and reorganization of exception handling for ``DoubleMLData`` objects
-      `#63 <https://github.com/DoubleML/doubleml-for-r/pull/63>`_ &
+      `#63 <https://github.com/DoubleML/doubleml-for-r/issues/63>`_ &
       `#90 <https://github.com/DoubleML/doubleml-for-r/pull/90>`_
     - Introduce style guide and clean up code
       `#80 <https://github.com/DoubleML/doubleml-for-r/pull/80>`_ &
@@ -198,7 +198,7 @@ Release notes
       `#86 <https://github.com/DoubleML/doubleml-for-r/pull/86>`_
     - Added a short version of and a reference to the arXiv paper as vignette
       `#110 <https://github.com/DoubleML/doubleml-for-r/pull/110>`_ &
-      `#113 <https://github.com/DoubleML/doubleml-for-r/pull/113>`_
+      `#113 <https://github.com/DoubleML/doubleml-for-r/issues/113>`_
     - Prevent using the subclassed methods check_score and check_data when constructing DoubleML objects
       `#107 <https://github.com/DoubleML/doubleml-for-r/pull/107>`_
     - Other refactoring and minor adaptions


### PR DESCRIPTION
This PR contains a reorganization of the GitHub action workflows. After merge we have four workflows
1) **Deploy Docu (stable)**:
   * Can only be triggered manually
   * Uses the most recent released packages of DoubleML (from pip and CRAN)
   * Html result is shipped to https://github.com/DoubleML/doubleml.github.io/tree/master/stable and rendered at https://docs.doubleml.org/stable/
2) **Deploy Docu (dev)**: 
   * Is triggered by every push to master and can be triggered manually
   * Uses the development versions of both DoubleML packages (current master of the two GitHub repos)
   * Html result is shipped to https://github.com/DoubleML/doubleml.github.io/tree/master/dev and rendered at https://docs.doubleml.org/dev/
3) **Test Docu Build (with dev pkgs)**:
   * Is triggered for PRs to master, on push to master, scheduled runs and can be triggered manually
   * Uses development versions of both DoubleML packages (branches can be selected on manual trigger; otherwise master)
   * Html result is provided as workflow artifact (see for example https://github.com/DoubleML/doubleml-docs/actions/runs/1741050890)
4) **Test Docu Build (with released pkgs)**:
   * Is triggered for PRs to master, on push to master, scheduled runs and can be triggered manually
   * Uses the most recent released packages of DoubleML (from pip and CRAN)
   * Html result is provided as workflow artifact

Improvements due to the new and adapted workflows (fixes #56):
- We distinguish between testing whether the build of the docu works and the actual deploy of the site. 1. & 2. is for deploying the docu. 3. & 4. for testing the build.
- We no longer re-deploy the same content with scheduled runs as we now have specific workflows for testing the build.
- Previously we only had scheduled tests with the dev versions of the packages, but not with the released versions (which is important for the deploy of the stable page). Now both combinations are tested. This is important as experienced recently (see #62).
- In the test workflows we now also check whether there are broken URLs with sphinx linkcheck (fixes #55).
- Previously there were no CI tests for PRs. Now 3. & 4. is triggered on PRs.
- @PhilippBach @FrederikBornemann If you want to try out something in the doubleml-docs repo please manually trigger the test workflows 3. and / or 4. and download the build artifacts if you want to see the html result. In the past we also used the dev deploy 2. for this which wasn't ideal as many different triggers wrote to the same dev page....
- The **Test Docu Build (with released pkgs)** currently fails due to #62. It will self-heal if we release a new version of the R package to CRAN.

@FrederikBornemann Could you briefly review the changes & additions
@PhilippBach FYI