### PR TITLE
Add cross-fitting animation to docs

### DIFF
--- a/doc/_templates/toc-doubleml-guide.html
+++ b/doc/_templates/toc-doubleml-guide.html
@@ -254,6 +254,7 @@
     window.onload = resizeAllGridItems();
     window.addEventListener("resize", resizeAllGridItems);
   });
+  resizeAllGridItems();
 </script>
 <script>
   console.log("test");

--- a/doc/guide/algorithms.rst
+++ b/doc/guide/algorithms.rst
@@ -59,6 +59,13 @@ The algorithm ``dml_procedure='dml2'`` can be summarized as
 
 4. **Outputs:** The estimate of the causal parameter :math:`\tilde{\theta}_0` as well as the values of the evaluate score function are returned.
 
+.. raw:: html
+
+    <p align="center">
+        <iframe width="400" height="300" src="https://www.youtube.com/embed/BMAr27rp4uA" title="Cross-Fitting Animation" frameborder="0" allowfullscreen></iframe>
+    </p>
+    
+
 Implementation of the double machine learning algorithms
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
This adds the animation from [this issue](https://github.com/DoubleML/doubleml-hiwi-sandbox/issues/19) to the docs. It is placed under the content of section "Algorithm DML2".

<img src="https://user-images.githubusercontent.com/78570169/184419938-9fcb8382-99c3-4129-8551-14d4d7e92b57.png" width="500">
