### PR TITLE
Fix version for sphinx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pytest
 rpy2
 
 # doc
-sphinx
+sphinx==4.5.0
 sphinx-copybutton
 nbsphinx
 sphinx-gallery


### PR DESCRIPTION
I fixed a version for sphinx in order to include the code examples, see #115 (actually #115 referred to virtually all code blocks in the documentation)

We should try to increment the version for shinx soon

closes #115 

