### PR TITLE
set default branch for dev docu to dev

### DIFF
--- a/.github/workflows/deploy_docu_dev.yml
+++ b/.github/workflows/deploy_docu_dev.yml
@@ -5,7 +5,7 @@ name: Deploy Docu (dev)
 on:
   push:
     branches:
-      - main
+      - dev
   workflow_dispatch:
 
 


### PR DESCRIPTION
I set the default branch for the "Deploy Docu (dev)" workflow to the branch https://github.com/DoubleML/doubleml-docs/tree/dev 

In the future, we should merge all changes on that branch and deploy https://docs.doubleml.org/dev/index.html from there using the development versions for the R and Python packages (as by their `main` branches). The stable docu should be deployed from the `main` branch using the released package.

