### PR TITLE
Update citation for R paper

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -210,7 +210,7 @@ Journal of Machine Learning Research, 23(53): 1-6,
 
 Bach, P., Chernozhukov, V., Kurz, M. S., Spindler, M.  and Klaassen, S. (2024),
 DoubleML - An Object-Oriented Implementation of Double Machine Learning in R, Journal of Statistical Software,
-108(3): 1-56, doi:`doi:10.18637/jss.v108.i03 <https://doi.org/10.18637/jss.v108.i03>`_, arXiv:`2103.09603 <https://arxiv.org/abs/2103.09603>`_.
+108(3): 1-56, doi:`10.18637/jss.v108.i03 <https://doi.org/10.18637/jss.v108.i03>`_, arXiv:`2103.09603 <https://arxiv.org/abs/2103.09603>`_.
 
 Bibtex-entries:
 
@@ -257,7 +257,7 @@ Journal of Machine Learning Research, 23(53): 1-6,
 
 Bach, P., Chernozhukov, V., Kurz, M. S., Spindler, M. and Klaassen, S. (2024),
 DoubleML - An Object-Oriented Implementation of Double Machine Learning in R, Journal of Statistical Software,
-108(3): 1-56, doi:`doi:10.18637/jss.v108.i03 <https://doi.org/10.18637/jss.v108.i03>`_, arXiv:`2103.09603 <https://arxiv.org/abs/2103.09603>`_.
+108(3): 1-56, doi:`10.18637/jss.v108.i03 <https://doi.org/10.18637/jss.v108.i03>`_, arXiv:`2103.09603 <https://arxiv.org/abs/2103.09603>`_.
 
 Chernozhukov, V., Chetverikov, D., Demirer, M., Duflo, E., Hansen, C., Newey, W. and Robins, J. (2018),
 Double/debiased machine learning for treatment and structural parameters. The Econometrics Journal, 21: C1-C68, doi:`10.1111/ectj.12097 <https://doi.org/10.1111/ectj.12097>`_.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -230,7 +230,7 @@ Bibtex-entries:
 .. code-block:: TeX
 
     @Article{doubleml2024R,
-      title   = {DoubleML: An Object-Oriented Implementation of Double Machine Learning in {R}},
+      title   = {{DoubleML}: {A}n Object-Oriented Implementation of Double Machine Learning in {R}},
       author  = {Philipp Bach and Malte S. Kurz and Victor Chernozhukov and Martin Spindler and Sven Klaassen},
       journal = {Journal of Statistical Software},
       year    = {2024},

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -210,7 +210,7 @@ Journal of Machine Learning Research, 23(53): 1-6,
 
 Bach, P., Chernozhukov, V., Kurz, M. S., Spindler, M.  and Klaassen, S. (2024),
 DoubleML - An Object-Oriented Implementation of Double Machine Learning in R, Journal of Statistical Software,
-108(3): 1-56, doi:`doi:10.18637/jss.v108.i03 <doi:10.18637/jss.v108.i03>`, arXiv:`2103.09603 <https://arxiv.org/abs/2103.09603>`_.
+108(3): 1-56, doi:`doi:10.18637/jss.v108.i03 <doi:10.18637/jss.v108.i03>`_, arXiv:`2103.09603 <https://arxiv.org/abs/2103.09603>`_.
 
 Bibtex-entries:
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -210,7 +210,7 @@ Journal of Machine Learning Research, 23(53): 1-6,
 
 Bach, P., Chernozhukov, V., Kurz, M. S., Spindler, M.  and Klaassen, S. (2024),
 DoubleML - An Object-Oriented Implementation of Double Machine Learning in R, Journal of Statistical Software,
-108(3): 1-56, doi:`doi:10.18637/jss.v108.i03 <doi:10.18637/jss.v108.i03>`_, arXiv:`2103.09603 <https://arxiv.org/abs/2103.09603>`_.
+108(3): 1-56, doi:`doi:10.18637/jss.v108.i03 <https://doi.org/10.18637/jss.v108.i03>`_, arXiv:`2103.09603 <https://arxiv.org/abs/2103.09603>`_.
 
 Bibtex-entries:
 
@@ -255,9 +255,9 @@ Object-Oriented Implementation of Double Machine Learning in Python,
 Journal of Machine Learning Research, 23(53): 1-6,
 `https://www.jmlr.org/papers/v23/21-0862.html  <https://www.jmlr.org/papers/v23/21-0862.html>`_.
 
-Bach, P., Chernozhukov, V., Kurz, M. S., and Spindler, M. (2021),
-DoubleML - An Object-Oriented Implementation of Double Machine Learning in R,
-arXiv:`2103.09603 <https://arxiv.org/abs/2103.09603>`_.
+Bach, P., Chernozhukov, V., Kurz, M. S., Spindler, M. and Klaassen, S. (2024),
+DoubleML - An Object-Oriented Implementation of Double Machine Learning in R, Journal of Statistical Software,
+108(3): 1-56, doi:`doi:10.18637/jss.v108.i03 <https://doi.org/10.18637/jss.v108.i03>`_, arXiv:`2103.09603 <https://arxiv.org/abs/2103.09603>`_.
 
 Chernozhukov, V., Chetverikov, D., Demirer, M., Duflo, E., Hansen, C., Newey, W. and Robins, J. (2018),
 Double/debiased machine learning for treatment and structural parameters. The Econometrics Journal, 21: C1-C68, doi:`10.1111/ectj.12097 <https://doi.org/10.1111/ectj.12097>`_.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -208,9 +208,9 @@ Journal of Machine Learning Research, 23(53): 1-6,
 `https://www.jmlr.org/papers/v23/21-0862.html  <https://www.jmlr.org/papers/v23/21-0862.html>`_.
 
 
-Bach, P., Chernozhukov, V., Kurz, M. S., and Spindler, M. (2021),
-DoubleML - An Object-Oriented Implementation of Double Machine Learning in R,
-arXiv:`2103.09603 <https://arxiv.org/abs/2103.09603>`_.
+Bach, P., Chernozhukov, V., Kurz, M. S., Spindler, M.  and Klaassen, S. (2024),
+DoubleML - An Object-Oriented Implementation of Double Machine Learning in R, Journal of Statistical Software,
+108(3): 1-56, doi:`doi:10.18637/jss.v108.i03 <doi:10.18637/jss.v108.i03>`, arXiv:`2103.09603 <https://arxiv.org/abs/2103.09603>`_.
 
 Bibtex-entries:
 
@@ -229,13 +229,15 @@ Bibtex-entries:
 
 .. code-block:: TeX
 
-    @misc{DoubleML2021R,
-      title={{DoubleML} -- {A}n Object-Oriented Implementation of Double Machine Learning in {R}},
-      author={P. Bach and V. Chernozhukov and M. S. Kurz and M. Spindler},
-      year={2021},
-      eprint={2103.09603},
-      archivePrefix={arXiv},
-      primaryClass={stat.ML},
+    @Article{doubleml2024R,
+      title   = {DoubleML: An Object-Oriented Implementation of Double Machine Learning in {R}},
+      author  = {Philipp Bach and Malte S. Kurz and Victor Chernozhukov and Martin Spindler and Sven Klaassen},
+      journal = {Journal of Statistical Software},
+      year    = {2024},
+      volume  = {108},
+      number  = {3},
+      pages   = {1--56},
+      doi     = {10.18637/jss.v108.i03},
       note={arXiv:\href{https://arxiv.org/abs/2103.09603}{2103.09603} [stat.ML]}
     }
 

--- a/doc/literature/literature.rst
+++ b/doc/literature/literature.rst
@@ -32,10 +32,11 @@ Double machine learning literature
         :octicon:`mark-github` :bdg-link-dark:`GitHub <https://github.com/DoubleML/doubleml-for-py>`
         |hr|
 
-      - Philipp Bach, Victor Chernozhukov, Malte S. Kurz, Martin Spindler |br|
+      - Philipp Bach, Victor Chernozhukov, Malte S. Kurz, Martin Spindler, Sven Klaassen |br|
         **DoubleML -- An Object-Oriented Implementation of Double Machine Learning in R** |br|
-        *arXiv preprint arXiv:2103.09603 [stat.ML], 2021* |br|
+        *Journal of Statistical Software, 108(3), 1-56, 2024* |br|
         :bdg-info:`R Package DoubleML` |br|
+        :octicon:`link` :bdg-link-dark:`URL <https://doi.org/10.18637/jss.v108.i03>`
         :octicon:`link` :bdg-link-dark:`arXiv <https://arxiv.org/abs/2103.09603>`
         :bdg-link-dark:`CRAN <https://cran.r-project.org/package=DoubleML>`
         :octicon:`mark-github` :bdg-link-dark:`GitHub <https://github.com/DoubleML/doubleml-for-r>`

--- a/doc/release/release.rst
+++ b/doc/release/release.rst
@@ -305,10 +305,15 @@ Release notes
 
   .. tab-item:: R
 
-    .. dropdown:: DoubleML 0.5.3
+    .. dropdown:: DoubleML 1.0.0
       :class-title: sd-bg-primary sd-font-weight-bold
       :open:
 
+      - Update citation info to publication in Journal of Statistical Software, rename helper function and fix links and GH actions
+        `191 <https://github.com/DoubleML/doubleml-for-r/pull/191>`_
+
+    .. dropdown:: DoubleML 0.5.3
+      :class-title: sd-bg-primary sd-font-weight-bold
       - Add documentation for estimated models for nuisance parameters
         `#181 <https://github.com/DoubleML/doubleml-for-r/pull/181>`_
       - New contributor `@SvenKlaassen <https://github.com/SvenKlaassen>`_


### PR DESCRIPTION
Update the citation for the R package paper to the published version at Journal of Statistical Software, see https://github.com/DoubleML/doubleml-for-r/pulls