### PR TITLE
Add framework documentation

### DIFF
--- a/doc/guide/resampling.rst
+++ b/doc/guide/resampling.rst
@@ -403,3 +403,9 @@ justification, see also :ref:`bias_overfitting`.
             set.seed(314)
             dml_plr_no_split$fit()
             dml_plr_no_split$summary()
+
+
+References
+++++++++++
+
+* Chernozhukov, Victor and Demirer, Mert and Duflo, Esther and Fernández-Val, Iván (2018), Generic Machine Learning Inference on Heterogeneous Treatment Effects in Randomized Experiments, with an Application to Immunization in India, National Bureau of Economic Research,  `doi: 10.3386/w24678 <https://dx.doi.org/10.3386/w24678>`_.

--- a/doc/guide/resampling.rst
+++ b/doc/guide/resampling.rst
@@ -249,6 +249,10 @@ The parameter estimates :math:`(\tilde{\theta}_{0,m})_{m \in [M]}` and asymptoti
             print(dml_plr_obj$all_coef)
             print(dml_plr_obj$all_se)
 
+In python, the confidence intervals and p-values are based on the :py:class:`doubleml.DoubleMLFramework` object.
+This class provides methods such as ``confint``, ``bootstrap`` or ``p_adjust``. For different repetitions, 
+the computations are done seperately and combined via the median (as based on Chernozhukov et al., 2018).
+
 Externally provide a sample splitting / partition
 +++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/doc/guide/se_confint.rst
+++ b/doc/guide/se_confint.rst
@@ -231,13 +231,10 @@ The number of bootstrap samples is provided as input ``n_rep_boot`` and for ``me
 ``'normal'`` or ``'wild'``.
 Based on the estimates of the standard errors :math:`\hat{\sigma}_j`
 and :math:`\hat{J}_{0,j} = \mathbb{E}_N(\psi_{a,j}(W; \eta_{0,j}))`
-that are obtained from DML, we construct bootstrap coefficients
-:math:`\theta^{*,b}_j` and bootstrap t-statistics :math:`t^{*,b}_j`
+that are obtained from DML, we construct bootstraped t-statistics :math:`t^{*,b}_j`
 for :math:`j=1, \ldots, p_1`
 
 .. math::
-
-    \theta^{*,b}_{j} &= \frac{1}{\sqrt{N} \hat{J}_{0,j}}\sum_{k=1}^{K} \sum_{i \in I_k} \xi_{i}^b \cdot \psi_j(W_i; \tilde{\theta}_{0,j}, \hat{\eta}_{0,j;k}),
 
     t^{*,b}_{j} &= \frac{1}{\sqrt{N} \hat{J}_{0,j} \hat{\sigma}_{j}} \sum_{k=1}^{K} \sum_{i \in I_k} \xi_{i}^b  \cdot \psi_j(W_i; \tilde{\theta}_{0,j}, \hat{\eta}_{0,j;k}).
 

--- a/doc/guide/se_confint.rst
+++ b/doc/guide/se_confint.rst
@@ -331,10 +331,10 @@ object contains a scaled version of the score function
 
 .. math::
 
-    \tilde{psi}(W_i; \theta, \eta) = \hat{J}_{0}^{-1}\psi(W_i; \hat{\theta}_{0}, \hat{\eta}_{0})
+    \tilde{\psi}(W_i; \theta, \eta) = \hat{J}_{0}^{-1}\psi(W_i; \hat{\theta}_{0}, \hat{\eta}_{0})
 
 which is used to construct confidence intervals. The framework objects can be concatenated using the
-:py:function:`doubleml.DoubleML.concat` function.
+:py:function:`doubleml.concat` function.
 
 .. tab-set::
 

--- a/doc/guide/se_confint.rst
+++ b/doc/guide/se_confint.rst
@@ -236,7 +236,7 @@ for :math:`j=1, \ldots, p_1`
 
 .. math::
 
-    t^{*,b}_{j} &= \frac{1}{\sqrt{N} \hat{J}_{0,j} \hat{\sigma}_{j}} \sum_{k=1}^{K} \sum_{i \in I_k} \xi_{i}^b  \cdot \psi_j(W_i; \tilde{\theta}_{0,j}, \hat{\eta}_{0,j;k}).
+    t^{*,b}_{j} = \frac{1}{\sqrt{N} \hat{J}_{0,j} \hat{\sigma}_{j}} \sum_{k=1}^{K} \sum_{i \in I_k} \xi_{i}^b  \cdot \psi_j(W_i; \tilde{\theta}_{0,j}, \hat{\eta}_{0,j;k}).
 
 The output of the multiplier bootstrap can be used to determine the constant, :math:`c_{1-\alpha}` that is required for the construction of a
 simultaneous :math:`(1-\alpha)` confidence band
@@ -315,6 +315,107 @@ via the option ``method``.
             dml_plr$confint(joint=TRUE)
             dml_plr$p_adjust()
             dml_plr$p_adjust(method="bonferroni")
+
+
+Simultaneous inference over different DoubleML models (advanced)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The :ref:`DoubleML <doubleml_package>` package provides a method to perform valid simultaneous inference over different DoubleML models.
+
+.. note::
+    Remark that the confidence intervals will generally only be valid if the stronger (uniform) assumptions on e.g. nuisance
+    estimates are satisfied. Further, the models should be estimated on the same data set.
+
+The :class:`doubleml.DoubleML` class contains a ``framework`` attribute which stores a :class:`doubleml.DoubleMLModelFramework` object. This
+object contains a scaled version of the score function
+
+.. math::
+
+    \tilde{psi}(W_i; \theta, \eta) = \hat{J}_{0}^{-1}\psi(W_i; \hat{\theta}_{0}, \hat{\eta}_{0})
+
+which is used to construct confidence intervals. The framework objects can be concatenated using the
+:py:function:`doubleml.DoubleML.concat` function.
+
+.. tab-set::
+
+    .. tab-item:: Python
+        :sync: py
+
+        .. ipython:: python
+
+            import doubleml as dml
+            import numpy as np
+            from sklearn.base import clone
+            from sklearn.linear_model import LassoCV
+            from sklearn.ensemble import RandomForestRegressor
+
+            import doubleml as dml
+
+            # Simulate data
+            np.random.seed(1234)
+            n_obs = 500
+            n_vars = 100
+            X = np.random.normal(size=(n_obs, n_vars))
+            theta = np.array([3., 3., 3.])
+            y = np.dot(X[:, :3], theta) + np.random.standard_normal(size=(n_obs,))
+
+            dml_data = dml.DoubleMLData.from_arrays(X[:, 10:], y, X[:, :10])
+
+            learner = LassoCV()
+            dml_plr_1 = dml.DoubleMLPLR(dml_data, clone(learner), clone(learner))
+
+            learner_rf = RandomForestRegressor()
+            dml_plr_2 = dml.DoubleMLPLR(dml_data, clone(learner_rf), clone(learner_rf))
+
+            dml_plr_1.fit()
+            dml_plr_2.fit()
+
+            dml_combined = dml.concat([dml_plr_1.framework, dml_plr_2.framework])
+            dml_combined.bootstrap().confint(joint=True)
+
+Frameworks can also be added or subtracted from each other. Of course, this changes the estimated parameter and should be used with caution. 
+
+
+.. tab-set::
+
+    .. tab-item:: Python
+        :sync: py
+
+        .. ipython:: python
+
+            import doubleml as dml
+            import numpy as np
+            from sklearn.base import clone
+            from sklearn.linear_model import LassoCV
+            from sklearn.ensemble import RandomForestRegressor
+
+            import doubleml as dml
+
+            # Simulate data
+            np.random.seed(1234)
+            n_obs = 500
+            n_vars = 100
+            X = np.random.normal(size=(n_obs, n_vars))
+            theta = np.array([3., 3., 3.])
+            y = np.dot(X[:, :3], theta) + np.random.standard_normal(size=(n_obs,))
+
+            dml_data = dml.DoubleMLData.from_arrays(X[:, 10:], y, X[:, :10])
+
+            learner = LassoCV()
+            dml_plr_1 = dml.DoubleMLPLR(dml_data, clone(learner), clone(learner))
+
+            learner_rf = RandomForestRegressor()
+            dml_plr_2 = dml.DoubleMLPLR(dml_data, clone(learner_rf), clone(learner_rf))
+
+            dml_plr_1.fit()
+            dml_plr_2.fit()
+
+            dml_combined = dml_plr_1.framework - dml_plr_2.framework
+            dml_combined.bootstrap().confint(joint=True)
+
+One possible use case is to substract the estimates from two average potential outcome models as e.g. in the :class:`DoubleMLQTE` example.
+
+This also works for multiple repetitions if both models have the same number of repetitions, as each repetition is treated seperately.
 
 
 References

--- a/doc/guide/se_confint.rst
+++ b/doc/guide/se_confint.rst
@@ -326,7 +326,7 @@ The :ref:`DoubleML <doubleml_package>` package provides a method to perform vali
     Remark that the confidence intervals will generally only be valid if the stronger (uniform) assumptions on e.g. nuisance
     estimates are satisfied. Further, the models should be estimated on the same data set.
 
-The :class:`doubleml.DoubleML` class contains a ``framework`` attribute which stores a :class:`doubleml.DoubleMLModelFramework` object. This
+The :py:class:`doubleml.DoubleML` class contains a ``framework`` attribute which stores a :py:class:`doubleml.DoubleMLFramework` object. This
 object contains a scaled version of the score function
 
 .. math::

--- a/doc/literature/literature.rst
+++ b/doc/literature/literature.rst
@@ -105,6 +105,12 @@ Double machine learning literature
         :octicon:`link` :bdg-link-dark:`URL <https://doi.org/10.1093/ectj/utaa001>`        
         |hr|
 
+      - Chernozhukov, Victor and Demirer, Mert and Duflo, Esther and Fernández-Val, Iván |br|
+        **Generic Machine Learning Inference on Heterogeneous Treatment Effects in Randomized Experiments, with an Application to Immunization in India** |br|
+        *National Bureau of Economic Research, Working Paper* |br|
+        :octicon:`link` :bdg-link-dark:`URL <https://doi.org/10.3386/w24678>`        
+        |hr|
+
       - Harold D. Chiang, Kengo Kato, Yukun Ma, Yuya Sasaki |br|
         **Multiway Cluster Robust Double/Debiased Machine Learning** |br|
         *Journal of Business & Economic Statistics, forthcoming, 2021* |br|


### PR DESCRIPTION
Add changes to resampling and variance estimation in the User Guide.

Now both sections refer to the `DoubleMLFramework` class and the implementation of confidence intervals.