### PR TITLE
Documentation Maintenance

### DIFF
--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -101,6 +101,8 @@ Utility classes
     utils.DMLDummyClassifier
     utils.DoubleMLBLP
     utils.DoubleMLPolicyTree
+    uitls.GlobalRegressor
+    utils.GlobalClassifier
 
 Utility functions
 ~~~~~~~~~~~~~~~~~

--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -101,7 +101,7 @@ Utility classes
     utils.DMLDummyClassifier
     utils.DoubleMLBLP
     utils.DoubleMLPolicyTree
-    uitls.GlobalRegressor
+    utils.GlobalRegressor
     utils.GlobalClassifier
 
 Utility functions

--- a/doc/examples/py_double_ml_pension.ipynb
+++ b/doc/examples/py_double_ml_pension.ipynb
@@ -97,23 +97,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "853ba4be",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Temporary fix for https://github.com/DoubleML/doubleml-docs/issues/45 / https://github.com/scikit-learn/scikit-learn/issues/21997\n",
-    "# Can be removed when scikit-learn version 1.2.0 is released\n",
-    "dtypes = data.dtypes\n",
-    "dtypes['nifa'] = 'float64'\n",
-    "dtypes['net_tfa'] = 'float64'\n",
-    "dtypes['tw'] = 'float64'\n",
-    "dtypes['inc'] = 'float64'\n",
-    "data = data.astype(dtypes)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "cf8659c7",
    "metadata": {},
    "outputs": [],
@@ -1179,7 +1162,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.12.4"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
- Remove precision fix for scikit-learn from 401k example notebook. The issue was fixed, see https://github.com/scikit-learn/scikit-learn/issues/21997
- Add `GlobalRegressor` and `GlobalClassifier` to api documentation