### PR TITLE
Update link to cross-fitting animation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -142,7 +142,7 @@ Double Machine Learning Algorithm
 .. raw:: html
 
     <p align="center">
-        <iframe width="500" height="400" src="https://www.youtube.com/embed/BMAr27rp4uA" title="Cross-Fitting Animation" frameborder="0" allowfullscreen></iframe>
+        <iframe width="500" height="400" src="https://www.youtube.com/embed/NWEoLe8mZqM?si=qJxpUOJb2ROqNogY" title="Cross-Fitting Animation" frameborder="0" allowfullscreen></iframe>
     </p>
 
 


### PR DESCRIPTION
Changing the link to an updated version of the cross-fitting animation (with the current logo)