### PR TITLE
Fix plotly version for examples

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,8 +14,12 @@ import os
 import sys
 
 import doubleml
+import plotly.io as pio
 
 sys.path.insert(0, os.path.abspath('..'))
+
+# Set the default renderer for Plotly
+pio.renderers.default = 'sphinx_gallery'
 
 # -- Project information -----------------------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ jupyter-sphinx
 pydata-sphinx-theme==0.15.4
 pickleshare
 matplotlib
-plotly
+plotly==5.24.1
 seaborn
 xgboost
 lightgbm

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ sphinx==8.1.3
 sphinx-copybutton
 nbsphinx==0.9.6
 ipykernel
-sphinx-gallery
+sphinx-gallery==0.18.0
 sphinx-panels
 sphinx-design
 jupyter-sphinx


### PR DESCRIPTION
Fix plotly version to `5.24.1`
Set plotly default renderer
