### PR TITLE
Add paper reference

### DIFF
--- a/doc/examples/py_double_ml_firststage.ipynb
+++ b/doc/examples/py_double_ml_firststage.ipynb
@@ -205,6 +205,8 @@
     "\n",
     "## References\n",
     "\n",
+    "Bach, P., Schacht, O., Chernozhukov, V., Klaassen, S., & Spindler, M. (2024, March). Hyperparameter Tuning for Causal Inference with Double Machine Learning: A Simulation Study. In Causal Learning and Reasoning (pp. 1065-1117). PMLR.\n",
+    "\n",
     "Alexandre Belloni, Victor Chernozhukov, and Christian Hansen. Inference on Treatment Effects after Selection among High-Dimensional Controls. *The Review of Economic Studies*, 81(2):608–650, 11 2013. ISSN 0034-6527. doi: 10.1093/restud/rdt044. URL https://doi.org/10.1093/restud/rdt044.\n",
     "\n",
     "\n",

--- a/doc/examples/py_double_ml_learner.ipynb
+++ b/doc/examples/py_double_ml_learner.ipynb
@@ -530,6 +530,15 @@
     "print(f'Time with LightGBM: {round(t_3_stop - t_3_start, 4)} seconds')\n",
     "print(f'Speedup of factor {round((t_1_stop - t_1_start) / (t_3_stop - t_3_start), 2)}')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "Bach, P., Schacht, O., Chernozhukov, V., Klaassen, S., & Spindler, M. (2024, March). Hyperparameter Tuning for Causal Inference with Double Machine Learning: A Simulation Study. In Causal Learning and Reasoning (pp. 1065-1117). PMLR."
+   ]
   }
  ],
  "metadata": {

--- a/doc/examples/py_double_ml_meets_flaml.ipynb
+++ b/doc/examples/py_double_ml_meets_flaml.ipynb
@@ -916,7 +916,11 @@
     "\n",
     "This notebook highlights that tuning plays an important role and can be easily done using FLAML AutoML. In our [recent study](https://arxiv.org/abs/2402.04674) we provide more evidence for tuning with AutoML, especially that the full sample case in all investigated cases performed similarly to the full sample case and thus tuning time and complexity can be saved by tuning externally.\n",
     "\n",
-    "See also our fully automated API for tuning DoubleML objects using AutoML, called [AutoDoubleML](https://github.com/OliverSchacht/AutoDoubleML) which can be installed from Github for python."
+    "See also our fully automated API for tuning DoubleML objects using AutoML, called [AutoDoubleML](https://github.com/OliverSchacht/AutoDoubleML) which can be installed from Github for python.\n",
+    "\n",
+    "## References\n",
+    "\n",
+    "Bach, P., Schacht, O., Chernozhukov, V., Klaassen, S., & Spindler, M. (2024, March). Hyperparameter Tuning for Causal Inference with Double Machine Learning: A Simulation Study. In Causal Learning and Reasoning (pp. 1065-1117). PMLR."
    ]
   }
  ],


### PR DESCRIPTION
I added the paper reference to the 2024 Clear paper to all notebooks on learner aspects

> Bach, P., Schacht, O., Chernozhukov, V., Klaassen, S., & Spindler, M. (2024, March). Hyperparameter Tuning for Causal Inference with Double Machine Learning: A Simulation Study. In Causal Learning and Reasoning (pp. 1065-1117). PMLR.