### PR TITLE
Fix for typo in SSM 

### DIFF
--- a/doc/examples/py_double_ml_multiway_cluster.ipynb
+++ b/doc/examples/py_double_ml_multiway_cluster.ipynb
@@ -150,7 +150,7 @@
    },
    "source": [
     "### Data-Backend for Cluster Data\n",
-    "The implementation of cluster robust double machine learning is based on a special data-backend called [DoubleMLClusterData](https://docs.doubleml.org/stable/api/generated/doubleml.DoubleMLClusterData.html#doubleml.DoubleMLClusterData). As compared to the standard data-backend [DoubleMLData](https://docs.doubleml.org/dev/api/generated/doubleml.DoubleMLData.html), users can specify the clustering variables during instantiation of a  [DoubleMLClusterData](https://docs.doubleml.org/stable/api/generated/doubleml.DoubleMLClusterData.html#doubleml.DoubleMLClusterData) object. The estimation framework will subsequently account for the provided clustering options."
+    "The implementation of cluster robust double machine learning is based on a special data-backend called [DoubleMLClusterData](https://docs.doubleml.org/stable/api/generated/doubleml.DoubleMLClusterData.html#doubleml.DoubleMLClusterData). As compared to the standard data-backend [DoubleMLData](https://docs.doubleml.org/stable/api/generated/doubleml.DoubleMLData.html), users can specify the clustering variables during instantiation of a  [DoubleMLClusterData](https://docs.doubleml.org/stable/api/generated/doubleml.DoubleMLClusterData.html#doubleml.DoubleMLClusterData) object. The estimation framework will subsequently account for the provided clustering options."
    ]
   },
   {

--- a/doc/examples/py_double_ml_pension.ipynb
+++ b/doc/examples/py_double_ml_pension.ipynb
@@ -294,7 +294,7 @@
    "id": "2e1fe478",
    "metadata": {},
    "source": [
-    "To start our analysis, we initialize the data backend, i.e., a new instance of a [DoubleMLData](https://docs.doubleml.org/dev/api/generated/doubleml.DoubleMLData.html#doubleml.DoubleMLData) object. We implement the regression model by using scikit-learn's `PolynomialFeatures` class.\n",
+    "To start our analysis, we initialize the data backend, i.e., a new instance of a [DoubleMLData](https://docs.doubleml.org/dev/api/generated/doubleml.data.DoubleMLData.html#doubleml.data.DoubleMLData) object. We implement the regression model by using scikit-learn's `PolynomialFeatures` class.\n",
     "\n",
     "To implement both models (basic and flexible), we generate two data backends: `data_dml_base` and `data_dml_flex`."
    ]

--- a/doc/guide/models/ssm/ssm_models.inc
+++ b/doc/guide/models/ssm/ssm_models.inc
@@ -81,7 +81,7 @@ with unobservables affecting :math:`Y_i` conditional on :math:`D_i` and :math:`X
 a (unknown) threshold model:
 
 - **Threshold:** :math:`S_i = 1\{V_i \le \xi(D,X,Z)\}` where :math:`\xi` is a general function and :math:`V_i` is a scalar with strictly monotonic cumulative distribution function conditional on :math:`X_i`.
-- **Cond. Independence:** :math:`Y_i \perp (Z_i, D_i)|X_i`.
+- **Cond. Independence:** :math:`V_i \perp (Z_i, D_i)|X_i`.
 
 Let :math:`\Pi_i := P(S_i=1|D_i, X_i, Z_i)` denote the selection probability.
 Additionally, the following assumptions are required:


### PR DESCRIPTION
Fix cond. independence under nonignorable nonresponse

I think this should be the correct form, see Assumption 4 in Bia et al. (2024) , https://doi.org/10.1080/07350015.2023.2271071 
 
![grafik](https://github.com/user-attachments/assets/64169b58-5d04-4783-a7e3-2d77fd4de8ed)
