### PR TITLE
Add reference to preprint describing robust confidence set

### DIFF
--- a/doc/examples/py_double_ml_robust_iv.ipynb
+++ b/doc/examples/py_double_ml_robust_iv.ipynb
@@ -10,6 +10,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6c070d4e",
    "metadata": {},
    "source": [
     "In this example we will show how to use the DoubleML package to obtain confidence sets for the treatment effects that are robust to weak instruments. Weak instruments are those that have a relatively weak correlation with the treatment. It is well known that in this case, standard methods to construct confidence intervals have poor properties and can have coverage much lower than the nominal value. We will assume that the reader of this notebook is already familiar with DoubleML and how it can be used to fit instrumental variable models.\n",
@@ -30,6 +31,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "f9e7a46f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,6 +48,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b6b976ce",
    "metadata": {},
    "source": [
     "# Running a small simulation"
@@ -211,6 +214,7 @@
     "- Chernozhukov, V., Chetverikov, D., Demirer, M., Duflo, E., and Hansen, C. (2018). Double/debiased machine learning for\n",
     "treatment and structural parameters. The Econometrics Journal, 21(1):C1–C68.\n",
     "- Ma, Y. (2023). Identification-robust inference for the late with high-dimensional covariates. arXiv preprint arXiv:2302.09756.\n",
+    "- Smucler, E., Lanni, L., Masip, D. (2025). A note on the properties of the confidence set for the local average treatment effect obtained by inverting the score test. arXiv preprint 2506.10449\n",
     "- Stock, J. H. and Wright, J. H. (2000). GMM with weak identification. Econometrica, 68(5):1055–1096.\n",
     "- Takatsu, K., Levis, A. W., Kennedy, E., Kelz, R., and Keele, L. (2023). Doubly robust machine learning for an instrumental\n",
     "variable study of surgical care for cholecystitis. arXiv preprint arXiv:2307.06269."

--- a/doc/examples/py_double_ml_robust_iv.ipynb
+++ b/doc/examples/py_double_ml_robust_iv.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "f9e7a46f",
    "metadata": {},
    "outputs": [],
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "82111204",
    "metadata": {},
    "outputs": [],
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "9a347c25",
    "metadata": {},
    "outputs": [],
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "600b8196",
    "metadata": {},
    "outputs": [],
@@ -166,26 +166,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "86c83edc",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                     DML coverage  Robust coverage  DML median length  \\\n",
-      "instrument_strength                                                     \n",
-      "0.003                        0.15             0.91           0.489567   \n",
-      "1.000                        0.93             0.92           0.572717   \n",
-      "\n",
-      "                     Robust median length  \n",
-      "instrument_strength                        \n",
-      "0.003                                 inf  \n",
-      "1.000                            0.582754  \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "results_df = pd.DataFrame(output_list)\n",
     "summary_df = results_df.groupby(\"instrument_strength\").agg(\n",

--- a/doc/examples/py_double_ml_robust_iv.ipynb
+++ b/doc/examples/py_double_ml_robust_iv.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "f9e7a46f",
    "metadata": {},
    "outputs": [],
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "82111204",
    "metadata": {},
    "outputs": [],
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "9a347c25",
    "metadata": {},
    "outputs": [],
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "600b8196",
    "metadata": {},
    "outputs": [],
@@ -166,10 +166,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "86c83edc",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                     DML coverage  Robust coverage  DML median length  \\\n",
+      "instrument_strength                                                     \n",
+      "0.003                        0.15             0.91           0.489567   \n",
+      "1.000                        0.93             0.92           0.572717   \n",
+      "\n",
+      "                     Robust median length  \n",
+      "instrument_strength                        \n",
+      "0.003                                 inf  \n",
+      "1.000                            0.582754  \n"
+     ]
+    }
+   ],
    "source": [
     "results_df = pd.DataFrame(output_list)\n",
     "summary_df = results_df.groupby(\"instrument_strength\").agg(\n",
@@ -221,7 +237,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi there. This is just adding a reference to this [preprint](https://arxiv.org/abs/2506.10449), which describes the recently added robust confidence set for the LATE in detail, as well as proving some theoretical results about it, reporting a simulation study and an application to real data.

Best,
Ezequiel