### PR TITLE
Fix a typo in Confit / SE part of user guide

### DIFF
--- a/doc/guide/se_confint.rst
+++ b/doc/guide/se_confint.rst
@@ -11,7 +11,7 @@ of :math:`\theta_0` and the sampling error :math:`\sqrt{N}(\tilde{\theta}_0 - \t
 
 .. math::
 
-    \sqrt{N}(\tilde{\theta}_0 - \theta_0) \leadsto N(o, \sigma^2),
+    \sqrt{N}(\tilde{\theta}_0 - \theta_0) \leadsto N(0, \sigma^2),
 
 with mean zero and variance given by
 


### PR DESCRIPTION
<img width="742" height="345" alt="grafik" src="https://github.com/user-attachments/assets/dcc452db-feb9-4120-9321-2a099644e8b5" />
